### PR TITLE
Handle exceptions in Query/Connection callbacks in client process

### DIFF
--- a/integration_test/cases/close_test.exs
+++ b/integration_test/cases/close_test.exs
@@ -100,6 +100,44 @@ defmodule CloseTest do
       handle_close: [%Q{}, _, :state]] = A.record(agent)
   end
 
+  test "close logs raise" do
+    stack = [
+      fn(opts) ->
+        Process.link(opts[:parent])
+        {:ok, :state}
+      end,
+      fn(_, _, _) ->
+        raise "oops"
+      end,
+      {:ok, :state2}
+      ]
+    {:ok, agent} = A.start_link(stack)
+
+    parent = self()
+    opts = [agent: agent, parent: parent]
+    _ = Process.flag(:trap_exit, true)
+    {:ok, pool} = P.start_link(opts)
+
+    log = fn(entry) ->
+      assert %DBConnection.LogEntry{call: :close, query: %Q{},
+                                    params: nil, result: {:error, err}} = entry
+      assert %DBConnection.ConnectionError{message: "an exception was raised: ** (RuntimeError) oops" <> _} = err
+      assert is_integer(entry.pool_time)
+      assert entry.pool_time >= 0
+      assert is_integer(entry.connection_time)
+      assert entry.connection_time >= 0
+      assert is_nil(entry.decode_time)
+      send(parent, :logged)
+    end
+    assert_raise RuntimeError, "oops", fn() -> P.close(pool, %Q{}, [log: log]) end
+    assert_received :logged
+    assert_receive {:EXIT, _, {%DBConnection.ConnectionError{}, [_|_]}}
+
+    assert [
+      {:connect, [_]},
+      {:handle_close, [%Q{}, _, :state]} | _] = A.record(agent)
+  end
+
   test "close! error raises error" do
     err = RuntimeError.exception("oops")
     stack = [

--- a/integration_test/cases/prepare_execute_test.exs
+++ b/integration_test/cases/prepare_execute_test.exs
@@ -98,7 +98,7 @@ defmodule PrepareExecuteTest do
       handle_execute: [_, :encoded, _, :new_state]] = A.record(agent)
   end
 
-  test "prepare_exeucte logs result" do
+  test "prepare_execute logs result" do
     stack = [
       {:ok, :state},
       {:ok, %Q{}, :new_state},
@@ -177,6 +177,188 @@ defmodule PrepareExecuteTest do
     assert [
       connect: [_],
       handle_prepare: [%Q{}, _, :state]] = A.record(agent)
+  end
+
+  test "prepare_execute logs prepare raise" do
+    stack = [
+      fn(opts) ->
+        Process.link(opts[:parent])
+        {:ok, :state}
+      end,
+      fn(_, _, _) ->
+        raise "oops"
+      end,
+      {:ok, :state2}
+      ]
+    {:ok, agent} = A.start_link(stack)
+
+    parent = self()
+    opts = [agent: agent, parent: parent]
+    _ = Process.flag(:trap_exit, true)
+    {:ok, pool} = P.start_link(opts)
+    log = fn(entry) ->
+      assert %DBConnection.LogEntry{call: :prepare_execute, query: %Q{},
+                                    params: [:param],
+                                    result: {:error, err}} = entry
+      assert %DBConnection.ConnectionError{message: "an exception was raised: ** (RuntimeError) oops" <> _} = err
+      assert is_integer(entry.pool_time)
+      assert entry.pool_time >= 0
+      assert is_integer(entry.connection_time)
+      assert entry.connection_time >= 0
+      assert is_nil(entry.decode_time)
+      send(parent, :logged)
+    end
+    assert_raise RuntimeError, "oops",
+      fn() -> P.prepare_execute(pool, %Q{}, [:param], [log: log]) end
+    assert_received :logged
+    assert_receive {:EXIT, _, {%DBConnection.ConnectionError{}, [_|_]}}
+
+    assert [
+      {:connect, [_]},
+      {:handle_prepare, [%Q{}, _, :state]} | _] = A.record(agent)
+  end
+
+  test "execute logs parse and describe raise" do
+    stack = [
+      {:ok, :state},
+      {:ok, %Q{}, :new_state},
+      {:ok, :closed, :newer_state}
+      ]
+    {:ok, agent} = A.start_link(stack)
+
+    parent = self()
+    opts = [agent: agent, parent: parent]
+    {:ok, pool} = P.start_link(opts)
+
+    log = fn(entry) ->
+      assert %DBConnection.LogEntry{call: :prepare_execute, query: %Q{},
+                                    params: [:param], result: {:error, err}} = entry
+      assert %DBConnection.ConnectionError{message: "an exception was raised: ** (RuntimeError) oops" <> _} = err
+      assert is_nil(entry.pool_time)
+      assert is_nil(entry.connection_time)
+      assert is_nil(entry.decode_time)
+      send(parent, :logged)
+    end
+    opts2 = [parse: fn(%Q{}) -> raise "oops" end, log: log]
+    assert_raise RuntimeError, "oops",
+      fn() -> P.prepare_execute(pool, %Q{}, [:param], opts2) end
+    assert_received :logged
+
+    log = fn(entry) ->
+      assert %DBConnection.LogEntry{call: :prepare_execute, query: %Q{},
+                                    params: [:param], result: {:error, err}} = entry
+      assert %DBConnection.ConnectionError{message: "an exception was raised: ** (RuntimeError) oops" <> _} = err
+      assert is_integer(entry.pool_time)
+      assert entry.pool_time >= 0
+      assert is_integer(entry.connection_time)
+      assert entry.connection_time >= 0
+      assert is_nil(entry.decode_time)
+      send(parent, :logged)
+    end
+    opts3 = [describe: fn(%Q{}) -> raise "oops" end, log: log]
+    assert_raise RuntimeError, "oops",
+      fn() -> P.prepare_execute(pool, %Q{}, [:param], opts3) end
+    assert_received :logged
+
+    assert [
+      connect: [_],
+      handle_prepare: [%Q{}, _, :state],
+      handle_close: [%Q{}, _, :new_state]] = A.record(agent)
+  end
+
+  test "prepare_execute logs encode and decode raise" do
+    stack = [
+      {:ok, :state},
+      {:ok, %Q{}, :new_state},
+      {:ok, :closed, :newer_state},
+      {:ok, %Q{}, :newest_state},
+      {:ok, %R{}, :state2}
+      ]
+    {:ok, agent} = A.start_link(stack)
+
+    parent = self()
+    opts = [agent: agent, parent: parent]
+    {:ok, pool} = P.start_link(opts)
+
+    log = fn(entry) ->
+      assert %DBConnection.LogEntry{call: :prepare_execute, query: %Q{},
+                                    params: [:param], result: {:error, err}} = entry
+      assert %DBConnection.ConnectionError{message: "an exception was raised: ** (RuntimeError) oops" <> _} = err
+      assert is_integer(entry.pool_time)
+      assert entry.pool_time >= 0
+      assert is_integer(entry.connection_time)
+      assert is_nil(entry.decode_time)
+      send(parent, :logged)
+    end
+    opts2 = [encode: fn([:param]) -> raise "oops" end, log: log]
+    assert_raise RuntimeError, "oops",
+      fn() -> P.prepare_execute(pool, %Q{}, [:param], opts2) end
+    assert_received :logged
+
+    log = fn(entry) ->
+      assert %DBConnection.LogEntry{call: :prepare_execute, query: %Q{},
+                                    params: [:param], result: {:error, err}} = entry
+      assert %DBConnection.ConnectionError{message: "an exception was raised: ** (RuntimeError) oops" <> _} = err
+      assert is_integer(entry.pool_time)
+      assert entry.pool_time >= 0
+      assert is_integer(entry.connection_time)
+      assert entry.connection_time >= 0
+      assert is_integer(entry.decode_time)
+      assert entry.decode_time >= 0
+      send(parent, :logged)
+    end
+    opts3 = [decode: fn(%R{}) -> raise "oops" end, log: log]
+    assert_raise RuntimeError, "oops",
+      fn() -> P.prepare_execute(pool, %Q{}, [:param], opts3) end
+    assert_received :logged
+
+    assert [
+      connect: [_],
+      handle_prepare: [%Q{}, _, :state],
+      handle_close: [%Q{}, _, :new_state],
+      handle_prepare: [%Q{}, _, :newer_state],
+      handle_execute: [%Q{}, [:param], _, :newest_state]] = A.record(agent)
+  end
+
+  test "prepare_execute logs execute raise" do
+    stack = [
+      fn(opts) ->
+        Process.link(opts[:parent])
+        {:ok, :state}
+      end,
+      {:ok, %Q{}, :new_state},
+      fn(_, _, _, _) ->
+        raise "oops"
+      end,
+      {:ok, :state2}
+      ]
+    {:ok, agent} = A.start_link(stack)
+
+    parent = self()
+    opts = [agent: agent, parent: parent]
+    _ = Process.flag(:trap_exit, true)
+    {:ok, pool} = P.start_link(opts)
+    log = fn(entry) ->
+      assert %DBConnection.LogEntry{call: :prepare_execute, query: %Q{},
+                                    params: [:param],
+                                    result: {:error, err}} = entry
+      assert %DBConnection.ConnectionError{message: "an exception was raised: ** (RuntimeError) oops" <> _} = err
+      assert is_integer(entry.pool_time)
+      assert entry.pool_time >= 0
+      assert is_integer(entry.connection_time)
+      assert entry.connection_time >= 0
+      assert is_nil(entry.decode_time)
+      send(parent, :logged)
+    end
+    assert_raise RuntimeError, "oops",
+      fn() -> P.prepare_execute(pool, %Q{}, [:param], [log: log]) end
+    assert_received :logged
+    assert_receive {:EXIT, _, {%DBConnection.ConnectionError{}, [_|_]}}
+
+    assert [
+      {:connect, [_]},
+      {:handle_prepare, [%Q{}, _, :state]},
+      {:handle_execute, [%Q{}, [:param], _, :new_state]} | _] = A.record(agent)
   end
 
   test "prepare_execute! error raises error" do

--- a/integration_test/cases/prepare_test.exs
+++ b/integration_test/cases/prepare_test.exs
@@ -136,6 +136,89 @@ defmodule PrepareTest do
       handle_prepare: [%Q{}, _, :state]] = A.record(agent)
   end
 
+  test "prepare logs raise" do
+    stack = [
+      fn(opts) ->
+        Process.link(opts[:parent])
+        {:ok, :state}
+      end,
+      fn(_, _, _) ->
+        raise "oops"
+      end,
+      {:ok, :state2}
+      ]
+    {:ok, agent} = A.start_link(stack)
+
+    parent = self()
+    opts = [agent: agent, parent: parent]
+    _ = Process.flag(:trap_exit, true)
+    {:ok, pool} = P.start_link(opts)
+    log = fn(entry) ->
+      assert %DBConnection.LogEntry{call: :prepare, query: %Q{},
+                                    params: nil, result: {:error, err}} = entry
+      assert %DBConnection.ConnectionError{message: "an exception was raised: ** (RuntimeError) oops" <> _} = err
+      assert is_integer(entry.pool_time)
+      assert entry.pool_time >= 0
+      assert is_integer(entry.connection_time)
+      assert entry.connection_time >= 0
+      assert is_nil(entry.decode_time)
+      send(parent, :logged)
+    end
+    assert_raise RuntimeError, "oops",
+      fn() -> P.prepare(pool, %Q{}, [log: log]) end
+    assert_received :logged
+    assert_receive {:EXIT, _, {%DBConnection.ConnectionError{}, [_|_]}}
+
+    assert [
+      {:connect, [_]},
+      {:handle_prepare, [%Q{}, _, :state]} | _] = A.record(agent)
+  end
+
+  test "prepare logs parse and describe raise" do
+    stack = [
+      {:ok, :state},
+      {:ok, %Q{}, :new_state}
+      ]
+    {:ok, agent} = A.start_link(stack)
+
+    parent = self()
+    opts = [agent: agent, parent: parent]
+    {:ok, pool} = P.start_link(opts)
+    log = fn(entry) ->
+      assert %DBConnection.LogEntry{call: :prepare, query: %Q{},
+                                    params: nil, result: {:error, err}} = entry
+      assert %DBConnection.ConnectionError{message: "an exception was raised: ** (RuntimeError) oops" <> _} = err
+      assert is_nil(entry.pool_time)
+      assert is_nil(entry.connection_time)
+      assert is_nil(entry.decode_time)
+      send(parent, :logged)
+    end
+    opts2 = [parse: fn(%Q{}) -> raise "oops" end, log: log]
+    assert_raise RuntimeError, "oops",
+      fn() -> P.prepare(pool, %Q{}, opts2) end
+    assert_received :logged
+
+    log = fn(entry) ->
+      assert %DBConnection.LogEntry{call: :prepare, query: %Q{},
+                                    params: nil, result: {:error, err}} = entry
+      assert %DBConnection.ConnectionError{message: "an exception was raised: ** (RuntimeError) oops" <> _} = err
+      assert is_integer(entry.pool_time)
+      assert entry.pool_time >= 0
+      assert is_integer(entry.connection_time)
+      assert entry.connection_time >= 0
+      assert is_nil(entry.decode_time)
+      send(parent, :logged)
+    end
+    opts3 = [describe: fn(%Q{}) -> raise "oops" end, log: log]
+    assert_raise RuntimeError, "oops",
+      fn() -> P.prepare(pool, %Q{}, opts3) end
+    assert_received :logged
+
+    assert [
+      connect: [_],
+      handle_prepare: [%Q{}, _, :state]] = A.record(agent)
+  end
+
   test "prepare! error raises error" do
     err = RuntimeError.exception("oops")
     stack = [

--- a/integration_test/cases/prepare_test.exs
+++ b/integration_test/cases/prepare_test.exs
@@ -177,7 +177,8 @@ defmodule PrepareTest do
   test "prepare logs parse and describe raise" do
     stack = [
       {:ok, :state},
-      {:ok, %Q{}, :new_state}
+      {:ok, %Q{}, :new_state},
+      {:ok, :result, :newer_state}
       ]
     {:ok, agent} = A.start_link(stack)
 
@@ -216,7 +217,8 @@ defmodule PrepareTest do
 
     assert [
       connect: [_],
-      handle_prepare: [%Q{}, _, :state]] = A.record(agent)
+      handle_prepare: [%Q{}, _, :state],
+      handle_close: [%Q{}, _, :new_state]] = A.record(agent)
   end
 
   test "prepare! error raises error" do

--- a/lib/db_connection.ex
+++ b/lib/db_connection.ex
@@ -958,10 +958,18 @@ defmodule DBConnection do
   end
 
   defp log(call, query, params, log, times, result) do
+    result = entry_result(result)
     entry = DBConnection.LogEntry.new(call, query, params, times, result)
     log(log, entry)
     log_result(result)
   end
+
+  defp entry_result({kind, reason, stack})
+  when kind in [:error, :exit, :throw] do
+    msg = "an exception was raised: " <> Exception.format(kind, reason, stack)
+    {:error, %DBConnection.ConnectionError{message: msg}}
+  end
+  defp entry_result(other), do: other
 
   defp log({mod, fun, args}, entry), do: apply(mod, fun, [entry | args])
   defp log(fun, entry), do: fun.(entry)

--- a/lib/db_connection.ex
+++ b/lib/db_connection.ex
@@ -958,8 +958,7 @@ defmodule DBConnection do
   end
 
   defp log(call, query, params, log, times, result) do
-    result = entry_result(result)
-    entry = DBConnection.LogEntry.new(call, query, params, times, result)
+    entry = DBConnection.LogEntry.new(call, query, params, times, entry_result(result))
     log(log, entry)
     log_result(result)
   end

--- a/lib/db_connection/log_entry.ex
+++ b/lib/db_connection/log_entry.ex
@@ -12,6 +12,7 @@ defmodule DBConnection.LogEntry do
     * `:call` - The `DBConnection` function called
     * `:query` - The query used by the function
     * `:params` - The params passed to the function (if any)
+    * `:result` - The result of the call
     * `:pool_time` - The length of time awaiting a connection from the pool (if
     the connection was not already checked out)
     * `:connection_time` - The length of time using the connection
@@ -24,6 +25,7 @@ defmodule DBConnection.LogEntry do
   @type t :: %__MODULE__{call: atom,
                          query: any,
                          params: any,
+                         result: {:ok, any} | {:ok, any, any} | {:error, Exception.t},
                          pool_time: non_neg_integer | nil,
                          connection_time: non_neg_integer,
                          decode_time: non_neg_integer | nil}

--- a/lib/db_connection/log_entry.ex
+++ b/lib/db_connection/log_entry.ex
@@ -39,6 +39,7 @@ defmodule DBConnection.LogEntry do
 
   ## Helpers
 
+  defp parse_times([], entry), do: entry
   defp parse_times([first | times], entry) do
     {_, entry} = Enum.reduce(times, {first, entry}, &parse_time/2)
     entry


### PR DESCRIPTION
This adds some major changes in error handling so requires tests plus review. I plan to add a commit which does more error handling in `prepare_execute` (closes prepared query if describe or encode raises).