### PR TITLE
Use Rand module over depreciated Random module

### DIFF
--- a/lib/db_connection/backoff.ex
+++ b/lib/db_connection/backoff.ex
@@ -104,7 +104,7 @@ defmodule DBConnection.Backoff do
   defp random_seed() do
     {_, sec, micro} = :os.timestamp()
     hash = :erlang.phash2({self(), make_ref()})
-    case :random.seed(hash, sec, micro) do
+    case :rand.seed(hash, [sec, micro]) do
       :undefined -> Process.delete(:random_seed)
       prev       -> Process.put(:random_seed, prev)
     end

--- a/lib/db_connection/backoff.ex
+++ b/lib/db_connection/backoff.ex
@@ -104,7 +104,7 @@ defmodule DBConnection.Backoff do
   defp random_seed() do
     {_, sec, micro} = :os.timestamp()
     hash = :erlang.phash2({self(), make_ref()})
-    case :rand.seed(hash, [sec, micro]) do
+    case :rand.seed(hash, {sec, micro}) do
       :undefined -> Process.delete(:random_seed)
       prev       -> Process.put(:random_seed, prev)
     end


### PR DESCRIPTION
Erlang's Random module is deprecated from 19.0. Using the Rand module is now encouraged.