### PR TITLE
Add manual ping

### DIFF
--- a/integration_test/cases/idle_test.exs
+++ b/integration_test/cases/idle_test.exs
@@ -44,6 +44,7 @@ defmodule TestIdle do
       ping: [:state]] = A.record(agent)
   end
 
+  @tag :idle_timeout
   test "ping manually" do
     err = RuntimeError.exception(message: "oops")
     stack = [

--- a/integration_test/cases/idle_test.exs
+++ b/integration_test/cases/idle_test.exs
@@ -43,4 +43,60 @@ defmodule TestIdle do
       ping: [:state],
       ping: [:state]] = A.record(agent)
   end
+
+  test "ping manually" do
+    err = RuntimeError.exception(message: "oops")
+    stack = [
+      {:ok, :state},
+      {:disconnect, err, :new_state},
+      :ok,
+      {:ok, :state2},
+      {:ok, :new_state2},
+      {:disconnect, err, :newer_state2},
+      :ok,
+      {:ok, :state3},
+      {:ok, :new_state3}
+      ]
+    {:ok, agent} = A.start_link(stack)
+
+    parent = self()
+    opts = [agent: agent, parent: parent]
+    {:ok, pool} = P.start_link(opts)
+
+    assert P.ping(pool) == :pang
+    assert P.ping(pool) == :pong
+
+    assert P.ping(pool, [log: &send(parent, &1)]) == :pang
+
+    assert_received %DBConnection.LogEntry{call: :ping} = entry
+    assert %{query: nil, params: nil, result: {:ok, :pang}} = entry
+    assert is_integer(entry.pool_time)
+    assert entry.pool_time >= 0
+    assert is_integer(entry.connection_time)
+    assert entry.connection_time >= 0
+    assert is_nil(entry.decode_time)
+
+
+    assert P.run(pool, fn(conn) ->
+      P.ping(conn, [log: &send(parent, &1)])
+    end) == :pong
+
+    assert_received %DBConnection.LogEntry{call: :ping} = entry
+    assert %{query: nil, params: nil, result: {:ok, :pong}} = entry
+    assert is_nil(entry.pool_time)
+    assert is_integer(entry.connection_time)
+    assert entry.connection_time >= 0
+    assert is_nil(entry.decode_time)
+
+    assert [
+      connect: [_],
+      ping: [:state],
+      disconnect: [^err, :new_state],
+      connect: [_],
+      ping: [:state2],
+      ping: [:new_state2],
+      disconnect: [^err, :newer_state2],
+      connect: [_],
+      ping: [:state3]] = A.record(agent)
+  end
 end

--- a/lib/db_connection.ex
+++ b/lib/db_connection.ex
@@ -138,7 +138,8 @@ defmodule DBConnection do
   timeout can be configured by the `:idle_timeout` option. This function
   can be called whether the connection is checked in or checked out.
 
-  This callback is called in the connection process.
+  This callback is called in either the connection process or the client
+  process.
   """
   @callback ping(state :: any) ::
     {:ok, new_state :: any} | {:disconnect, Exception.t, new_state :: any}
@@ -898,6 +899,35 @@ defmodule DBConnection do
     %DBConnection.Stream{conn: conn, query: query, params: params, opts: opts}
   end
 
+  @doc """
+  Ping the database on the connection.
+
+  Returns `:ping` on success or `:pang` on failure.
+
+  ### Options
+
+    * `:pool_timeout` - The maximum time to wait for a reply when making a
+    synchronous call to the pool (default: `5_000`)
+    * `:queue` - Whether to block waiting in an internal queue for the
+    connection's state (boolean, default: `true`)
+    * `:timeout` - The maximum time that the caller is allowed the
+    to hold the connection's state (default: `15_000`)
+    * `:log` - A function to log information about begin, commit and rollback
+    calls made as part of the transaction, either a 1-arity fun,
+    `{module, function, args}` with `DBConnection.LogEntry.t` prepended to
+    `args` or `nil`. See `DBConnection.LogEntry` (default: `nil`)
+  """
+  @spec ping(conn, opts :: Keyword.t) :: :pong | :pang
+  def ping(conn, opts \\ []) do
+    case run_ping(conn, opts) do
+      {{:ok, _} = ok, meter} ->
+        {:ok, result} = log(:ping, nil, nil, meter, ok)
+        result
+      {error, meter} ->
+        log(:ping, nil, nil, meter, error)
+    end
+  end
+
   @doc false
   def reduce(%DBConnection.PrepareStream{} = stream, acc, fun) do
     %DBConnection.PrepareStream{conn: conn, query: query, params: params,
@@ -1509,6 +1539,38 @@ defmodule DBConnection do
     next = fn(state) -> next.(conn, state, opts) end
     stop = fn(state) -> stop.(conn, state, opts) end
     Stream.resource(start, next, stop)
+  end
+
+  defp run_ping(conn, opts) do
+    run_meter(conn, fn(conn2) -> handle_ping(conn2, opts) end, opts)
+  end
+
+  defp handle_ping(%DBConnection{conn_mod: conn_mod} = conn, opts) do
+    {status, conn_state} = fetch_info(conn)
+    try do
+      apply(conn_mod, :ping, [conn_state])
+    else
+      {:ok, conn_state} ->
+        put_info(conn, status, conn_state)
+        {:ok, :pong}
+      {:disconnect, err, conn_state} ->
+        delete_disconnect(conn, conn_state, err, opts)
+        {:ok, :pang}
+      other ->
+        try do
+          raise DBConnection.ConnectionError, "bad return value: #{inspect other}"
+        catch
+          :error, reason ->
+            stack = System.stacktrace()
+            delete_stop(conn, conn_state, :error, reason, stack, opts)
+            {:error, reason, stack}
+        end
+    catch
+      kind, reason ->
+        stack = System.stacktrace()
+        delete_stop(conn, conn_state, kind, reason, stack, opts)
+        {kind, reason, stack}
+    end
   end
 
   defp put_info(conn, status, conn_state) do

--- a/test/test_support.exs
+++ b/test/test_support.exs
@@ -63,6 +63,10 @@ defmodule TestConnection do
         DBConnection.close!(pool, query, opts2 ++ unquote(opts))
       end
 
+      def ping(pool, opts2 \\ []) do
+        DBConnection.ping(pool, opts2 ++ unquote(opts))
+      end
+
       defoverridable [start_link: 1]
     end
   end


### PR DESCRIPTION
Required a bit more code than I would like because had connection process callback return but it is simple and clear, and most code is tests. Will work with mariaex and postgrex without changes there. For https://github.com/elixir-ecto/ecto/issues/1789.