### PR TITLE
Fix ownership caller to use caller on auto/shared

### DIFF
--- a/integration_test/ownership/manager_test.exs
+++ b/integration_test/ownership/manager_test.exs
@@ -111,8 +111,22 @@ defmodule ManagerTest do
       assert_checked_out pool, [caller: parent]
       send parent, :checkin
     end
-
     assert_receive :checkin
+
+    assert Ownership.ownership_mode(pool, :auto, [])
+    Task.start_link fn ->
+      assert_checked_out pool, [caller: parent]
+      send parent, :checkin
+    end
+    assert_receive :checkin
+
+    assert Ownership.ownership_mode(pool, {:shared, parent}, [])
+    Task.start_link fn ->
+      assert_checked_out pool, [caller: parent]
+      send parent, :checkin
+    end
+    assert_receive :checkin
+
     assert_checked_out pool, [caller: parent]
   end
 

--- a/lib/db_connection/ownership.ex
+++ b/lib/db_connection/ownership.ex
@@ -128,39 +128,33 @@ defmodule DBConnection.Ownership do
       {:ok, proxy} ->
         Proxy.checkout(proxy, opts)
       :not_found ->
-        case Keyword.pop(opts, :caller) do
-          {nil, _} ->
-            msg = """
-            cannot find ownership process for #{inspect self()}.
+        msg = """
+        cannot find ownership process for #{inspect self()}.
 
-            When using ownership, you must manage connections in one
-            of the four ways:
+        When using ownership, you must manage connections in one
+        of the four ways:
 
-              * By explicitly checking out a connection
-              * By explicitly allowing a spawned process
-              * By running the pool in shared mode
-              * By using :caller option with allowed process
+        * By explicitly checking out a connection
+        * By explicitly allowing a spawned process
+        * By running the pool in shared mode
+        * By using :caller option with allowed process
 
-            The first two options require every new process to explicitly
-            check a connection out or be allowed by calling checkout or
-            allow respectively.
-            
-            The third option requires a {:shared, pid} mode to be set.
-            If using shared mode in tests, make sure your tests are not
-            async.
+        The first two options require every new process to explicitly
+        check a connection out or be allowed by calling checkout or
+        allow respectively.
 
-            The fourth option requires [caller: pid] to be used when
-            checking out a connection from the pool. The caller process
-            should already be allowed on a connection.
+        The third option requires a {:shared, pid} mode to be set.
+        If using shared mode in tests, make sure your tests are not
+        async.
 
-            If you are reading this error, it means you have not done one
-            of the steps above or that the owner process has crashed.
-            """
-            {:error, DBConnection.OwnershipError.exception(msg)}
-          {owner, opts} ->
-            ownership_allow(manager, owner, self(), opts)
-            checkout(manager, [pool_timeout: :infinity] ++ opts)
-        end
+        The fourth option requires [caller: pid] to be used when
+        checking out a connection from the pool. The caller process
+        should already be allowed on a connection.
+
+        If you are reading this error, it means you have not done one
+        of the steps above or that the owner process has crashed.
+        """
+        {:error, DBConnection.OwnershipError.exception(msg)}
     end
   end
 

--- a/lib/db_connection/ownership/manager.ex
+++ b/lib/db_connection/ownership/manager.ex
@@ -102,13 +102,16 @@ defmodule DBConnection.Ownership.Manager do
     {:reply, :ok, %{state | mode: mode, mode_ref: nil}}
   end
 
-  def handle_call({:lookup, opts}, {caller, _},
+  def handle_call({:lookup, opts}, {pid, _},
                   %{checkouts: checkouts, mode: mode} = state) do
+    caller = Keyword.get(opts, :caller, pid)
     case Map.get(checkouts, caller, :not_found) do
       {:owner, _, proxy} ->
         {:reply, {:ok, proxy}, state}
       {:allowed, _, proxy} ->
         {:reply, {:ok, proxy}, state}
+      :not_found when caller != pid ->
+        {:reply, :not_found, state}
       :not_found when mode == :manual ->
         {:reply, :not_found, state}
       :not_found when mode == :auto ->


### PR DESCRIPTION
Always use :caller when option is set, and fail if :caller does not have a proxy.

We should release patch to fix this issue. A caller process will get a new proxy in `:auto` mode regardless of `caller` and will get the proxy of `owner` in `{:shared, owner}` even if `caller` is not `owner`.