### PR TITLE
Allow running cleanup in failed transactions

### DIFF
--- a/integration_test/cases/close_test.exs
+++ b/integration_test/cases/close_test.exs
@@ -154,4 +154,31 @@ defmodule CloseTest do
       connect: [_],
       handle_close: [%Q{}, _, :state]] = A.record(agent)
   end
+
+  test "close in failed transaction" do
+    stack = [
+      {:ok, :state},
+      {:ok, :began, :new_state},
+      {:ok, :result, :newer_state},
+      {:ok, :rolledback, :newest_state}
+      ]
+    {:ok, agent} = A.start_link(stack)
+
+    opts = [agent: agent, parent: self()]
+    {:ok, pool} = P.start_link(opts)
+
+    assert P.transaction(pool, fn(conn) ->
+      assert P.transaction(conn, fn(conn2) ->
+        P.rollback(conn2, :oops)
+      end) == {:error, :oops}
+
+      assert P.close(conn, %Q{}, opts) == {:ok, :result}
+    end) == {:error, :rollback}
+
+    assert [
+      connect: [_],
+      handle_begin: [_, :state],
+      handle_close: [%Q{}, _, :new_state],
+      handle_rollback: [_, :newer_state]] = A.record(agent)
+  end
 end

--- a/lib/db_connection.ex
+++ b/lib/db_connection.ex
@@ -756,10 +756,11 @@ defmodule DBConnection do
 
   `run/3` and `transaction/3` can be nested multiple times. If a transaction is
   rolled back or a nested transaction `fun` raises the transaction is marked as
-  failed. Any calls inside a failed transaction (except `rollback/2`) will raise
-  until the outer transaction call returns. All running `transaction/3` calls
-  will return `{:error, :rollback}` if the transaction failed or connection
-  closed and `rollback/2` is not called for that `transaction/3`.
+  failed. All calls except `run/3`, `transaction/3`, `rollback/2`, `close/3` and
+  `close!/3` will raise an exception inside a failed transaction until the outer
+  transaction call returns. All `transaction/3` calls will return
+  `{:error, :rollback}` if the transaction failed or connection closed and
+  `rollback/2` is not called for that `transaction/3`.
 
   ### Options
 


### PR DESCRIPTION
This is  a crucial bug fix as cursors might not be deallocated in some drivers as the deallocation call would raise but the connection would remain open. Also we should be allowing cleanup of prepared queries with `close` once a transaction failed to prevent leaking statements.

This would also help with #82 as deallocate in terminate/2 would always be possible.