### PR TITLE
No longer raise if logging raises

### DIFF
--- a/integration_test/cases/transaction_execute_test.exs
+++ b/integration_test/cases/transaction_execute_test.exs
@@ -264,7 +264,7 @@ defmodule TransactionExecuteTest do
       end) == {:error, :oops}
 
       assert_raise DBConnection.ConnectionError, "transaction rolling back",
-        fn() -> P.execute(conn, %Q{}, [:param]) end
+        fn() -> P.execute!(conn, %Q{}, [:param]) end
     end) == {:error, :rollback}
 
     assert [

--- a/lib/db_connection/log_entry.ex
+++ b/lib/db_connection/log_entry.ex
@@ -15,19 +15,20 @@ defmodule DBConnection.LogEntry do
     * `:result` - The result of the call
     * `:pool_time` - The length of time awaiting a connection from the pool (if
     the connection was not already checked out)
-    * `:connection_time` - The length of time using the connection
+    * `:connection_time` - The length of time using the connection (if a
+    connection was used)
     * `:decode_time` - The length of time decoding the result (if decoded the
     result using `DBConnection.Query.decode/3`)
 
   All times are in the native time units of the VM, see
-  `System.monotonic_time/0`. Falls back to `:os.timestamp/0`.
+  `System.monotonic_time/0`.
   """
   @type t :: %__MODULE__{call: atom,
                          query: any,
                          params: any,
                          result: {:ok, any} | {:ok, any, any} | {:error, Exception.t},
                          pool_time: non_neg_integer | nil,
-                         connection_time: non_neg_integer,
+                         connection_time: non_neg_integer | nil,
                          decode_time: non_neg_integer | nil}
 
   @doc false
@@ -40,26 +41,20 @@ defmodule DBConnection.LogEntry do
   ## Helpers
 
   defp parse_times([], entry), do: entry
-  defp parse_times([first | times], entry) do
-    {_, entry} = Enum.reduce(times, {first, entry}, &parse_time/2)
+  defp parse_times(times, entry) do
+    stop = :erlang.monotonic_time()
+    {_, entry} = Enum.reduce(times, {stop, entry}, &parse_time/2)
     entry
   end
 
-  defmacrop diff(to, from) do
-    if function_exported?(:erlang, :monotonic_time, 0) do
-      quote do: unquote(to) - unquote(from)
-    else
-      quote do: max(:timer.now_diff(unquote(to), unquote(from)), 0)
-    end
+  defp parse_time({:decode, start}, {stop, entry}) do
+    {start, %{entry | decode_time: stop - start}}
   end
-
-  defp parse_time({:stop, stop} = time, {{:decode, decode}, entry}) do
-    {time, %{entry | decode_time: diff(decode, stop)}}
+  defp parse_time({:checkout, start}, {stop, entry}) do
+    {start, %{entry | pool_time: stop - start}}
   end
-  defp parse_time({:start, start} = time, {{:stop, stop}, entry}) do
-    {time, %{entry | connection_time: diff(stop, start)}}
-  end
-  defp parse_time({:checkout, checkout} = time, {{:start, start}, entry}) do
-    {time, %{entry | pool_time: diff(start, checkout)}}
+  defp parse_time({_, start}, {stop, entry}) do
+    %{connection_time: connection_time} = entry
+    {start, %{entry | connection_time: (connection_time || 0) + (stop - start)}}
   end
 end


### PR DESCRIPTION
First commit changes the behaviour and the second commit does a substantial refactor to help with #82 and any future metrics work. Hopefully this will pave the way for future integration with any standard instrumentation lib. This PR uses a stateful approach because it fits well with multiple timestampings. However all "connection_time" work is carried out inside a closure except begin/commit/rollback.