### PR TITLE
Switch to non-closure based transactions

### DIFF
--- a/integration_test/cases/run_test.exs
+++ b/integration_test/cases/run_test.exs
@@ -1,4 +1,4 @@
-defmodule TransactionExecuteTest do
+defmodule RunTest do
   use ExUnit.Case, async: true
 
   alias TestPool, as: P
@@ -6,39 +6,33 @@ defmodule TransactionExecuteTest do
   alias TestQuery, as: Q
   alias TestResult, as: R
 
-  test "execute returns result" do
+  test "run execute returns result" do
     stack = [
       {:ok, :state},
-      {:ok, :began, :new_state},
-      {:ok, %R{}, :newer_state},
-      {:ok, %R{}, :newest_state},
-      {:ok, :committed, :newest_state}
+      {:ok, %R{}, :new_state},
+      {:ok, %R{}, :newer_state}
       ]
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
-    assert P.transaction(pool, fn(conn) ->
+    assert P.run(pool, fn(conn) ->
       assert P.execute(conn, %Q{}, [:param]) == {:ok, %R{}}
       assert P.execute(conn, %Q{}, [:param], [key: :value]) == {:ok, %R{}}
       :hi
-    end) == {:ok, :hi}
+    end) == :hi
 
     assert [
       connect: [_],
-      handle_begin: [_, :state],
-      handle_execute: [%Q{}, [:param], _, :new_state],
-      handle_execute: [%Q{}, [:param],
-        [{:key, :value} | _], :newer_state],
-      handle_commit: [_, :newest_state]] = A.record(agent)
+      handle_execute: [%Q{}, [:param], _, :state],
+      handle_execute: [%Q{}, [:param], [{:key, :value} | _], :new_state]
+      ] = A.record(agent)
   end
 
-  test "execute logs result" do
+  test "run execute logs result" do
     stack = [
       {:ok, :state},
-      {:ok, :began, :new_state},
-      {:ok, %R{}, :newer_state},
-      {:ok, :committed, :newest_state}
+      {:ok, %R{}, :new_state}
       ]
     {:ok, agent} = A.start_link(stack)
 
@@ -57,84 +51,76 @@ defmodule TransactionExecuteTest do
       assert entry.decode_time >= 0
       send(parent, :logged)
     end
-    assert P.transaction(pool, fn(conn) ->
+    assert P.run(pool, fn(conn) ->
       assert P.execute(conn, %Q{}, [:param], [log: log]) == {:ok, %R{}}
       :hi
-    end) == {:ok, :hi}
+    end) == :hi
 
     assert_received :logged
     assert [
       connect: [_],
-      handle_begin: [_, :state],
-      handle_execute: [%Q{}, [:param], _, :new_state],
-      handle_commit: [_, :newer_state]] = A.record(agent)
+      handle_execute: [%Q{}, [:param], _, :state]
+      ] = A.record(agent)
   end
 
-  test "execute error returns error" do
+  test "run execute error returns error" do
     err = RuntimeError.exception("oops")
     stack = [
       {:ok, :state},
-      {:ok, :began, :new_state},
-      {:error, err, :newer_state},
-      {:ok, :committed, :newest_state}
+      {:error, err, :newer_state}
       ]
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
 
-    assert P.transaction(pool, fn(conn) ->
+    assert P.run(pool, fn(conn) ->
       assert P.execute(conn, %Q{}, [:param]) == {:error, err}
       :hi
-    end) == {:ok, :hi}
+    end) == :hi
 
     assert [
       connect: [_],
-      handle_begin: [_, :state],
-      handle_execute: [%Q{}, [:param], _, :new_state],
-      handle_commit: [_, :newer_state]] = A.record(agent)
+      handle_execute: [%Q{}, [:param], _, :state]
+      ] = A.record(agent)
   end
 
-  test "execute! error raises error" do
+  test "run execute! error raises error" do
     err = RuntimeError.exception("oops")
     stack = [
       {:ok, :state},
-      {:ok, :began, :new_state},
-      {:error, err, :newer_state},
-      {:ok,  %R{}, :newest_state},
-      {:ok, :committed, :newest_state}
+      {:error, err, :new_state},
+      {:ok,  %R{}, :newer_state},
       ]
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
 
-    assert P.transaction(pool, fn(conn) ->
+    assert P.run(pool, fn(conn) ->
       assert_raise RuntimeError, "oops",
         fn() -> P.execute!(conn, %Q{}, [:param]) end
 
       assert P.execute(conn, %Q{}, [:param]) == {:ok, %R{}}
       :hi
-    end) == {:ok, :hi}
+    end) == :hi
 
     assert [
       connect: [_],
-      handle_begin: [_, :state],
+      handle_execute: [%Q{}, [:param], _, :state],
       handle_execute: [%Q{}, [:param], _, :new_state],
-      handle_execute: [%Q{}, [:param], _, :newer_state],
-      handle_commit: [_, :newest_state]] = A.record(agent)
+      ] = A.record(agent)
   end
 
-  test "execute disconnect returns error" do
+  test "run execute disconnect returns error" do
     err = RuntimeError.exception("oops")
     stack = [
       {:ok, :state},
-      {:ok, :began, :new_state},
-      {:disconnect, err, :newer_state},
+      {:disconnect, err, :new_state},
       :ok,
       fn(opts) ->
         send(opts[:parent], :reconnected)
-        {:ok, :state}
+        {:ok, :state2}
       end
       ]
     {:ok, agent} = A.start_link(stack)
@@ -142,33 +128,31 @@ defmodule TransactionExecuteTest do
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
 
-    assert P.transaction(pool, fn(conn) ->
+    assert P.run(pool, fn(conn) ->
       assert P.execute(conn, %Q{}, [:param]) == {:error, err}
 
       assert_raise DBConnection.ConnectionError, "connection is closed",
-        fn() -> P.execute(conn, %Q{}, [:param]) end
+        fn() -> P.execute!(conn, %Q{}, [:param]) end
 
       :closed
-    end) == {:error, :rollback}
+    end) == :closed
 
     assert_receive :reconnected
 
     assert [
       connect: [opts2],
-      handle_begin: [_, :state],
-      handle_execute: [%Q{}, [:param], _, :new_state],
-      disconnect: [^err, :newer_state],
+      handle_execute: [%Q{}, [:param], _, :state],
+      disconnect: [^err, :new_state],
       connect: [opts2]] = A.record(agent)
   end
 
-  test "execute bad return raises DBConnection.ConnectionError and stops" do
+  test "run execute bad return raises DBConnection.ConnectionError and stops" do
     stack = [
       fn(opts) ->
         send(opts[:parent], {:hi, self()})
         Process.link(opts[:parent])
         {:ok, :state}
       end,
-      {:ok, :began, :new_state},
       :oops,
       {:ok, :state}
       ]
@@ -180,15 +164,15 @@ defmodule TransactionExecuteTest do
 
     Process.flag(:trap_exit, true)
 
-    assert P.transaction(pool, fn(conn) ->
+    assert P.run(pool, fn(conn) ->
       assert_raise DBConnection.ConnectionError, "bad return value: :oops",
         fn() -> P.execute(conn, %Q{}, [:param]) end
 
       assert_raise DBConnection.ConnectionError, "connection is closed",
-        fn() -> P.execute(conn, %Q{}, [:param]) end
+        fn() -> P.execute!(conn, %Q{}, [:param]) end
 
       :closed
-    end) == {:error, :rollback}
+    end) == :closed
 
     prefix = "client #{inspect self()} stopped: " <>
       "** (DBConnection.ConnectionError) bad return value: :oops"
@@ -199,18 +183,16 @@ defmodule TransactionExecuteTest do
 
     assert [
       {:connect, _},
-      {:handle_begin, [_, :state]},
-      {:handle_execute, [%Q{}, [:param], _, :new_state]} | _] = A.record(agent)
+      {:handle_execute, [%Q{}, [:param], _, :state]} | _] = A.record(agent)
   end
 
-  test "execute raise raises and stops connection" do
+  test "run execute raise raises and stops connection" do
     stack = [
       fn(opts) ->
         send(opts[:parent], {:hi, self()})
         Process.link(opts[:parent])
         {:ok, :state}
       end,
-      {:ok, :began, :new_state},
       fn(_, _, _, _) ->
         raise "oops"
       end,
@@ -224,15 +206,15 @@ defmodule TransactionExecuteTest do
 
     Process.flag(:trap_exit, true)
 
-    assert P.transaction(pool, fn(conn) ->
+    assert P.run(pool, fn(conn) ->
       assert_raise RuntimeError, "oops",
         fn() -> P.execute(conn, %Q{}, [:param]) end
 
       assert_raise DBConnection.ConnectionError, "connection is closed",
-        fn() -> P.execute(conn, %Q{}, [:param]) end
+        fn() -> P.execute!(conn, %Q{}, [:param]) end
 
       :closed
-    end) == {:error, :rollback}
+    end) == :closed
 
 
     prefix = "client #{inspect self()} stopped: ** (RuntimeError) oops"
@@ -243,65 +225,6 @@ defmodule TransactionExecuteTest do
 
     assert [
       {:connect, _},
-      {:handle_begin, [_, :state]},
-      {:handle_execute, [%Q{}, [:param], _, :new_state]}| _] = A.record(agent)
-  end
-
-  test "execute raises after inner transaction rollback" do
-    stack = [
-      {:ok, :state},
-      {:ok, :began, :new_state},
-      {:ok, :rolledback, :newer_state}
-      ]
-    {:ok, agent} = A.start_link(stack)
-
-    opts = [agent: agent, parent: self()]
-    {:ok, pool} = P.start_link(opts)
-
-    assert P.transaction(pool, fn(conn) ->
-      assert P.transaction(conn, fn(conn2) ->
-        P.rollback(conn2, :oops)
-      end) == {:error, :oops}
-
-      assert_raise DBConnection.ConnectionError, "transaction rolling back",
-        fn() -> P.execute!(conn, %Q{}, [:param]) end
-    end) == {:error, :rollback}
-
-    assert [
-      connect: [_],
-      handle_begin: [ _, :state],
-      handle_rollback: [_, :new_state]] = A.record(agent)
-  end
-
-  test "transaction does not log commit if closed" do
-   stack = [
-      {:ok, :state},
-      {:ok, :began, :new_state},
-      :oops,
-      {:ok, :state2}
-      ]
-    {:ok, agent} = A.start_link(stack)
-
-    parent = self()
-    opts = [agent: agent, parent: parent]
-    Process.flag(:trap_exit, true)
-    {:ok, pool} = P.start_link(opts)
-
-    log = &send(parent, &1)
-
-    P.transaction(pool, fn(conn) ->
-      assert_received %DBConnection.LogEntry{call: :transaction,
-        query: :begin}
-      assert_raise DBConnection.ConnectionError,
-        fn() -> P.execute(conn, %Q{}, [:param]) end
-    end, [log: log])
-
-    refute_received %DBConnection.LogEntry{call: :transaction}
-
-    assert [
-      {:connect, [_]},
-      {:handle_begin, [_, :state]},
-      {:handle_execute, [%Q{}, [:param], _, :new_state]} |
-      _] = A.record(agent)
+      {:handle_execute, [%Q{}, [:param], _, :state]}| _] = A.record(agent)
   end
 end

--- a/integration_test/cases/transaction_test.exs
+++ b/integration_test/cases/transaction_test.exs
@@ -4,43 +4,46 @@ defmodule TransactionTest do
   alias TestPool, as: P
   alias TestAgent, as: A
 
-  test "transaction returns result" do
-    stack = [
-      {:ok, :state},
-      {:ok, :began, :new_state},
-      {:ok, :comitted, :newer_state},
-      {:ok, :began, :newest_state},
-      {:ok, :committed, :newest_state}
-      ]
-    {:ok, agent} = A.start_link(stack)
-
-    opts = [agent: agent, parent: self()]
-    {:ok, pool} = P.start_link(opts)
-
-    assert P.transaction(pool, fn(conn) ->
-      assert %DBConnection{} = conn
-      :result
-    end) == {:ok, :result}
-
-    assert P.transaction(pool, fn(conn) ->
-      assert %DBConnection{} = conn
-      :result
-    end, [key: :value]) == {:ok, :result}
-
-    assert [
-      connect: [_],
-      handle_begin: [ _, :state],
-      handle_commit: [_, :new_state],
-      handle_begin: [[{:key, :value} | _], :newer_state],
-      handle_commit: [[{:key, :value} | _], :newest_state]] = A.record(agent)
-  end
-
-  test "transaction logs begin/commit/rollback" do
+  test "begin/commit/rollback return result" do
     stack = [
       {:ok, :state},
       {:ok, :began, :new_state},
       {:ok, :committed, :newer_state},
-      {:ok, :began, :newest_state},
+      {:ok, :rolledback, :newest_state},
+      {:ok, :began, :state2},
+      {:ok, :committed, :new_state2},
+      {:ok, :rolledback, :newer_state2}
+      ]
+    {:ok, agent} = A.start_link(stack)
+
+    opts = [agent: agent, parent: self()]
+    {:ok, pool} = P.start_link(opts)
+
+    assert P.begin(pool, opts) == {:ok, :began}
+    assert P.commit(pool, opts) == {:ok, :committed}
+    assert P.rollback(pool, opts) == {:ok, :rolledback}
+
+    opts2 = [key: :value] ++ opts
+    assert P.begin(pool, opts2) == {:ok, :began}
+    assert P.commit(pool, opts2) == {:ok, :committed}
+    assert P.rollback(pool, opts2) == {:ok, :rolledback}
+
+    assert [
+      connect: [_],
+      handle_begin: [ _, :state],
+      handle_commit: [_, :new_state],
+      handle_rollback: [_, :newer_state],
+      handle_begin: [[{:key, :value} | _], :newest_state],
+      handle_commit: [[{:key, :value} | _], :state2],
+      handle_rollback: [[{:key, :value} | _], :new_state2]
+    ] = A.record(agent)
+  end
+
+  test "begin/commit/rollback log results" do
+    stack = [
+      {:ok, :state},
+      {:ok, :began, :new_state},
+      {:ok, :committed, :newer_state},
       {:ok, :rolledback, :newest_state}
       ]
     {:ok, agent} = A.start_link(stack)
@@ -51,33 +54,32 @@ defmodule TransactionTest do
 
     log = &send(parent, &1)
 
-    assert P.transaction(pool, fn(_) ->
-      assert_received %DBConnection.LogEntry{call: :transaction} = entry
-      assert %{query: :begin, params: nil, result: {:ok, :began}} = entry
-      assert is_integer(entry.pool_time)
-      assert entry.pool_time >= 0
-      assert is_integer(entry.connection_time)
-      assert entry.connection_time >= 0
-      assert is_nil(entry.decode_time)
+    assert P.begin(pool, [log: log] ++ opts) == {:ok, :began}
 
-      :result
-    end, [log: log]) == {:ok, :result}
-
-    assert_received %DBConnection.LogEntry{call: :transaction} = entry
-    assert %{query: :commit, params: nil, result: {:ok, :committed}} = entry
-    assert is_nil(entry.pool_time)
+    assert_received %DBConnection.LogEntry{call: :begin} = entry
+    assert %{query: :begin, params: nil, result: {:ok, :began}} = entry
+    assert is_integer(entry.pool_time)
+    assert entry.pool_time >= 0
     assert is_integer(entry.connection_time)
     assert entry.connection_time >= 0
     assert is_nil(entry.decode_time)
 
-    assert P.transaction(pool, fn(conn) ->
-      assert_received %DBConnection.LogEntry{}
-      P.rollback(conn, :result)
-    end, [log: log]) == {:error, :result}
+    assert P.commit(pool, [log: log] ++ opts) == {:ok, :committed}
 
-    assert_received %DBConnection.LogEntry{call: :transaction} = entry
+    assert_received %DBConnection.LogEntry{call: :commit} = entry
+    assert %{query: :commit, params: nil, result: {:ok, :committed}} = entry
+    assert is_integer(entry.pool_time)
+    assert entry.pool_time >= 0
+    assert is_integer(entry.connection_time)
+    assert entry.connection_time >= 0
+    assert is_nil(entry.decode_time)
+
+    assert P.rollback(pool, [log: log] ++ opts) == {:ok, :rolledback}
+
+    assert_received %DBConnection.LogEntry{call: :rollback} = entry
     assert %{query: :rollback, params: nil, result: {:ok, :rolledback}} = entry
-    assert is_nil(entry.pool_time)
+    assert is_integer(entry.pool_time)
+    assert entry.pool_time >= 0
     assert is_integer(entry.connection_time)
     assert entry.connection_time >= 0
     assert is_nil(entry.decode_time)
@@ -86,211 +88,41 @@ defmodule TransactionTest do
       connect: [_],
       handle_begin: [ _, :state],
       handle_commit: [_, :new_state],
-      handle_begin: [_, :newer_state],
-      handle_rollback: [_, :newest_state]] = A.record(agent)
+      handle_rollback: [_, :newer_state]] = A.record(agent)
   end
 
-  test "transaction rollback returns error" do
-    stack = [
-      {:ok, :state},
-      {:ok, :began, :new_state},
-      {:ok, :rolledback, :newer_state},
-      {:ok, :began, :newest_state},
-      {:ok, :rolledback, :newest_state}
-      ]
-    {:ok, agent} = A.start_link(stack)
-
-    opts = [agent: agent, parent: self()]
-    {:ok, pool} = P.start_link(opts)
-
-    assert P.transaction(pool, fn(conn) ->
-      P.rollback(conn, :oops)
-    end) == {:error, :oops}
-
-    assert P.transaction(pool, fn(_) -> :result end) == {:ok, :result}
-
-    assert [
-      connect: [_],
-      handle_begin: [ _, :state],
-      handle_rollback: [_, :new_state],
-      handle_begin: [_, :newer_state],
-      handle_commit: [_, :newest_state]] = A.record(agent)
-  end
-
-  test "inner transaction rollback returns error on other transactions" do
-    stack = [
-      {:ok, :state},
-      {:ok, :began, :new_state},
-      {:ok, :rolledback, :newer_state},
-      {:ok, :began, :newest_state},
-      {:ok, :comittted, :newest_state}
-      ]
-    {:ok, agent} = A.start_link(stack)
-
-    opts = [agent: agent, parent: self()]
-    {:ok, pool} = P.start_link(opts)
-
-    assert P.transaction(pool, fn(conn) ->
-      assert P.transaction(conn, fn(conn2) ->
-        P.rollback(conn2, :oops)
-      end) == {:error, :oops}
-
-      assert P.transaction(conn, fn(_) -> nil end) == {:error, :rollback}
-    end) == {:error, :rollback}
-
-    assert P.transaction(pool, fn(_) -> :result end) == {:ok, :result}
-
-    assert [
-      connect: [_],
-      handle_begin: [ _, :state],
-      handle_rollback: [_, :new_state],
-      handle_begin: [_, :newer_state],
-      handle_commit: [_, :newest_state]] = A.record(agent)
-  end
-
-  test "outer transaction rolls back after inner rollback" do
-    stack = [
-      {:ok, :state},
-      {:ok, :began, :new_state},
-      {:ok, :rolledback, :newer_state},
-      {:ok, :began, :newest_state},
-      {:ok, :committed, :newest_state}
-      ]
-    {:ok, agent} = A.start_link(stack)
-
-    opts = [agent: agent, parent: self()]
-    {:ok, pool} = P.start_link(opts)
-
-    assert P.transaction(pool, fn(conn) ->
-      assert P.transaction(conn, fn(conn2) ->
-        P.rollback(conn2, :oops)
-      end) == {:error, :oops}
-
-      P.rollback(conn, :oops2)
-    end) == {:error, :oops2}
-
-    assert P.transaction(pool, fn(_) -> :result end) == {:ok, :result}
-
-    assert [
-      connect: [_],
-      handle_begin: [ _, :state],
-      handle_rollback: [_, :new_state],
-      handle_begin: [_, :newer_state],
-      handle_commit: [_, :newest_state]] = A.record(agent)
-  end
-
-  test "inner transaction raise returns error on other transactions" do
-    stack = [
-      {:ok, :state},
-      {:ok, :began, :new_state},
-      {:ok, :rolledback, :newer_state},
-      {:ok, :began, :newest_state},
-      {:ok, :committed, :newest_state}
-      ]
-    {:ok, agent} = A.start_link(stack)
-
-    opts = [agent: agent, parent: self()]
-    {:ok, pool} = P.start_link(opts)
-
-    assert P.transaction(pool, fn(conn) ->
-      assert_raise RuntimeError, "oops",
-       fn() -> P.transaction(conn, fn(_) -> raise "oops" end) end
-
-      assert P.transaction(conn, fn(_) -> nil end) ==  {:error, :rollback}
-    end) == {:error, :rollback}
-
-    assert P.transaction(pool, fn(_) -> :result end) == {:ok, :result}
-
-    assert [
-      connect: [_],
-      handle_begin: [ _, :state],
-      handle_rollback: [_, :new_state],
-      handle_begin: [_, :newer_state],
-      handle_commit: [_, :newest_state]] = A.record(agent)
-  end
-
-  test "transaction and transaction returns result" do
-    stack = [
-      {:ok, :state},
-      {:ok, :began, :new_state},
-      {:ok, :committed, :newer_state}
-      ]
-    {:ok, agent} = A.start_link(stack)
-
-    opts = [agent: agent, parent: self()]
-    {:ok, pool} = P.start_link(opts)
-
-    assert P.transaction(pool, fn(conn) ->
-      assert P.transaction(conn, fn(conn2) ->
-        assert %DBConnection{} = conn2
-        assert conn == conn2
-        :result
-      end) == {:ok, :result}
-      :result
-    end) == {:ok, :result}
-
-    assert [
-      connect: [_],
-      handle_begin: [ _, :state],
-      handle_commit: [_, :new_state]] = A.record(agent)
-  end
-
-  test "transaction and run returns result" do
-    stack = [
-      {:ok, :state},
-      {:ok, :began, :new_state},
-      {:ok, :committed, :newer_state}
-      ]
-    {:ok, agent} = A.start_link(stack)
-
-    opts = [agent: agent, parent: self()]
-    {:ok, pool} = P.start_link(opts)
-
-    assert P.transaction(pool, fn(conn) ->
-      assert P.run(conn, fn(conn2) ->
-        assert %DBConnection{} = conn2
-        assert conn == conn2
-        :result
-      end) == :result
-      :result
-    end) == {:ok, :result}
-
-    assert [
-      connect: [_],
-      handle_begin: [ _, :state],
-      handle_commit: [_, :new_state]] = A.record(agent)
-  end
-
-  test "transaction begin error raises error" do
+  test "begin!/commit!/rollback! error raises error" do
     err = RuntimeError.exception("oops")
     stack = [
       {:ok, :state},
       {:error, err, :new_state},
-      {:ok, :began, :newer_state},
-      {:ok, :committed, :newest_state}
+      {:error, err, :newer_state},
+      {:error, err, :newest_state}
       ]
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
 
-    assert_raise RuntimeError, "oops",
-      fn() -> P.transaction(pool, fn(_) -> flunk("transaction ran") end) end
-
-    assert P.transaction(pool, fn(_) -> :result end) == {:ok, :result}
+    assert_raise RuntimeError, "oops", fn() -> P.begin!(pool, opts) end
+    assert_raise RuntimeError, "oops", fn() -> P.commit!(pool, opts) end
+    assert_raise RuntimeError, "oops", fn() -> P.rollback!(pool, opts) end
 
     assert [
       connect: [_],
       handle_begin: [ _, :state],
-      handle_begin: [_, :new_state],
-      handle_commit: [_, :newer_state]] = A.record(agent)
+      handle_commit: [_, :new_state],
+      handle_rollback: [_, :newer_state]
+      ] = A.record(agent)
   end
 
-  test "transaction logs begin error" do
+  test "begin/commit/rollback logs error" do
     err = RuntimeError.exception("oops")
     stack = [
       {:ok, :state},
-      {:error, err, :new_state}
+      {:error, err, :new_state},
+      {:error, err, :newer_state},
+      {:error, err, :newest_state}
       ]
     {:ok, agent} = A.start_link(stack)
 
@@ -299,12 +131,10 @@ defmodule TransactionTest do
     {:ok, pool} = P.start_link(opts)
 
     log = &send(parent, &1)
-    assert_raise RuntimeError, "oops",
-      fn() ->
-        P.transaction(pool, fn(_) -> flunk("transaction ran") end, [log: log])
-      end
 
-    assert_received %DBConnection.LogEntry{call: :transaction} = entry
+    assert P.begin(pool, [log: log] ++ opts) == {:error, err}
+
+    assert_received %DBConnection.LogEntry{call: :begin} = entry
     assert %{query: :begin, params: nil, result: {:error, ^err}} = entry
     assert is_integer(entry.pool_time)
     assert entry.pool_time >= 0
@@ -312,51 +142,35 @@ defmodule TransactionTest do
     assert entry.connection_time >= 0
     assert is_nil(entry.decode_time)
 
-    assert [
-      connect: [_],
-      handle_begin: [ _, :state]] = A.record(agent)
-  end
+    assert P.commit(pool, [log: log] ++ opts) == {:error, err}
 
-  test "transaction logs begin raise" do
-    stack = [
-      fn(opts) ->
-        Process.link(opts[:parent])
-        {:ok, :state}
-      end,
-      fn(_, _) ->
-        raise "oops"
-      end,
-      {:ok, :state2}
-      ]
-    {:ok, agent} = A.start_link(stack)
-
-    parent = self()
-    opts = [agent: agent, parent: parent]
-    _ = Process.flag(:trap_exit, true)
-    {:ok, pool} = P.start_link(opts)
-
-    log = &send(parent, &1)
-    assert_raise RuntimeError, "oops",
-      fn() ->
-        P.transaction(pool, fn(_) -> flunk("transaction ran") end, [log: log])
-      end
-
-    assert_received %DBConnection.LogEntry{call: :transaction} = entry
-    assert %{query: :begin, params: nil, result: {:error, err}} = entry
-    assert %DBConnection.ConnectionError{message: "an exception was raised: ** (RuntimeError) oops" <> _} = err
+    assert_received %DBConnection.LogEntry{call: :commit} = entry
+    assert %{query: :commit, params: nil, result: {:error, ^err}} = entry
     assert is_integer(entry.pool_time)
     assert entry.pool_time >= 0
     assert is_integer(entry.connection_time)
     assert entry.connection_time >= 0
     assert is_nil(entry.decode_time)
-    assert_receive {:EXIT, _, {%DBConnection.ConnectionError{}, [_|_]}}
+
+    assert P.rollback(pool, [log: log] ++ opts) == {:error, err}
+
+    assert_received %DBConnection.LogEntry{call: :rollback} = entry
+    assert %{query: :rollback, params: nil, result: {:error, ^err}} = entry
+    assert is_integer(entry.pool_time)
+    assert entry.pool_time >= 0
+    assert is_integer(entry.connection_time)
+    assert entry.connection_time >= 0
+    assert is_nil(entry.decode_time)
 
     assert [
-      {:connect, [_]},
-      {:handle_begin, [ _, :state]} | _] = A.record(agent)
+      connect: [_],
+      handle_begin: [_, :state],
+      handle_commit: [_, :new_state],
+      handle_rollback: [_, :newer_state]
+      ] = A.record(agent)
   end
 
-  test "transaction begin disconnect raises error" do
+  test "begin! disconnect raises error" do
     err = RuntimeError.exception("oops")
     stack = [
       {:ok, :state},
@@ -372,8 +186,7 @@ defmodule TransactionTest do
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
 
-    assert_raise RuntimeError, "oops",
-      fn() -> P.transaction(pool, fn(_) -> flunk("transaction ran") end) end
+    assert_raise RuntimeError, "oops", fn() -> P.begin!(pool, opts) end
 
     assert_receive :reconnected
 
@@ -384,7 +197,7 @@ defmodule TransactionTest do
       connect: [_]] = A.record(agent)
   end
 
-  test "transaction begin bad return raises and stops connection" do
+  test "begin bad return raises and stops connection" do
     stack = [
       fn(opts) ->
         send(opts[:parent], {:hi, self()})
@@ -398,16 +211,16 @@ defmodule TransactionTest do
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
-    assert_receive {:hi, conn}
+    assert_receive {:hi, pid}
 
     Process.flag(:trap_exit, true)
     assert_raise DBConnection.ConnectionError, "bad return value: :oops",
-      fn() -> P.transaction(pool, fn(_) -> flunk("transaction ran") end) end
+      fn() -> P.begin(pool, opts) end
 
     prefix = "client #{inspect self()} stopped: " <>
       "** (DBConnection.ConnectionError) bad return value: :oops"
     len = byte_size(prefix)
-    assert_receive {:EXIT, ^conn,
+    assert_receive {:EXIT, ^pid,
       {%DBConnection.ConnectionError{message: <<^prefix::binary-size(len), _::binary>>},
         [_|_]}}
 
@@ -416,7 +229,7 @@ defmodule TransactionTest do
       {:handle_begin, [_, :state]}| _] = A.record(agent)
   end
 
-  test "transaction begin raise raises and stops connection" do
+  test "begin raise raises and stops connection" do
     stack = [
       fn(opts) ->
         send(opts[:parent], {:hi, self()})
@@ -432,15 +245,15 @@ defmodule TransactionTest do
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
-    assert_receive {:hi, conn}
+    assert_receive {:hi, pid}
 
     Process.flag(:trap_exit, true)
     assert_raise RuntimeError, "oops",
-      fn() -> P.transaction(pool, fn(_) -> flunk("transaction ran") end) end
+      fn() -> P.begin(pool, opts) end
 
     prefix = "client #{inspect self()} stopped: ** (RuntimeError) oops"
     len = byte_size(prefix)
-    assert_receive {:EXIT, ^conn,
+    assert_receive {:EXIT, ^pid,
       {%DBConnection.ConnectionError{message: <<^prefix::binary-size(len), _::binary>>},
        [_|_]}}
 
@@ -449,57 +262,85 @@ defmodule TransactionTest do
       {:handle_begin, [_, :state]} | _] = A.record(agent)
   end
 
-  test "transaction commit error raises error" do
+  test "run begin!/commit!/rollback! error raises error" do
     err = RuntimeError.exception("oops")
     stack = [
       {:ok, :state},
-      {:ok, :began, :new_state},
+      {:error, err, :new_state},
       {:error, err, :newer_state},
-      {:ok, :began, :newest_state},
-      {:ok, :committed, :newest_state}
+      {:error, err, :newest_state}
       ]
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
 
-    assert_raise RuntimeError, "oops",
-      fn() -> P.transaction(pool, fn(_) -> :ok end) end
+    assert P.run(pool, fn(conn) ->
+      assert_raise RuntimeError, "oops", fn() -> P.begin!(conn, opts) end
+      assert_raise RuntimeError, "oops", fn() -> P.commit!(conn, opts) end
+      assert_raise RuntimeError, "oops", fn() -> P.rollback!(conn, opts) end
 
-    assert P.transaction(pool, fn(_) -> :result end) == {:ok, :result}
+      :hi
+    end) == :hi
 
     assert [
       connect: [_],
-      handle_begin: [_, :state],
+      handle_begin: [ _, :state],
       handle_commit: [_, :new_state],
-      handle_begin: [_, :newer_state],
-      handle_commit: [_, :newest_state]] = A.record(agent)
+      handle_rollback: [_, :newer_state]
+      ] = A.record(agent)
   end
 
-  test "transaction logs commit error" do
+  test "run begin/commit/rollback logs error" do
     err = RuntimeError.exception("oops")
     stack = [
       {:ok, :state},
-      {:ok, :began, :new_state},
+      {:error, err, :new_state},
       {:error, err, :newer_state},
+      {:error, err, :newest_state}
       ]
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
-    opts = [agent: agent, parent: self()]
+    opts = [agent: agent, parent: parent]
     {:ok, pool} = P.start_link(opts)
 
     log = &send(parent, &1)
 
-    assert_raise RuntimeError, "oops",
-      fn() ->
-        P.transaction(pool, fn(_) ->
-          assert_received %DBConnection.LogEntry{}
-        end, [log: log])
-      end
+    assert P.run(pool, fn(conn) ->
+      assert P.begin(conn, [log: log] ++ opts) == {:error, err}
 
-    assert_received %DBConnection.LogEntry{call: :transaction} = entry
+      :hi
+    end) == :hi
+
+    assert_received %DBConnection.LogEntry{call: :begin} = entry
+    assert %{query: :begin, params: nil, result: {:error, ^err}} = entry
+    assert is_nil(entry.pool_time)
+    assert is_integer(entry.connection_time)
+    assert entry.connection_time >= 0
+    assert is_nil(entry.decode_time)
+
+    assert P.run(pool, fn(conn) ->
+      assert P.commit(conn, [log: log] ++ opts) == {:error, err}
+
+      :hi
+    end) == :hi
+
+    assert_received %DBConnection.LogEntry{call: :commit} = entry
     assert %{query: :commit, params: nil, result: {:error, ^err}} = entry
+    assert is_nil(entry.pool_time)
+    assert is_integer(entry.connection_time)
+    assert entry.connection_time >= 0
+    assert is_nil(entry.decode_time)
+
+    assert P.run(pool, fn(conn) ->
+      assert P.rollback(conn, [log: log] ++ opts) == {:error, err}
+
+      :hi
+    end) == :hi
+
+    assert_received %DBConnection.LogEntry{call: :rollback} = entry
+    assert %{query: :rollback, params: nil, result: {:error, ^err}} = entry
     assert is_nil(entry.pool_time)
     assert is_integer(entry.connection_time)
     assert entry.connection_time >= 0
@@ -508,15 +349,16 @@ defmodule TransactionTest do
     assert [
       connect: [_],
       handle_begin: [_, :state],
-      handle_commit: [_, :new_state]] = A.record(agent)
+      handle_commit: [_, :new_state],
+      handle_rollback: [_, :newer_state]
+      ] = A.record(agent)
   end
 
-  test "transaction commit disconnect raises error" do
+  test "run begin! disconnect raises error" do
     err = RuntimeError.exception("oops")
     stack = [
       {:ok, :state},
-      {:ok, :began, :new_state},
-      {:disconnect, err, :newer_state},
+      {:disconnect, err, :new_state},
       :ok,
       fn(opts) ->
         send(opts[:parent], :reconnected)
@@ -528,27 +370,28 @@ defmodule TransactionTest do
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
 
-    assert_raise RuntimeError, "oops",
-      fn() -> P.transaction(pool, fn(_) -> :result end) end
+    assert P.run(pool, fn(conn) ->
+      assert_raise RuntimeError, "oops", fn() -> P.begin!(conn, opts) end
+
+      :hi
+    end) == :hi
 
     assert_receive :reconnected
 
     assert [
       connect: [_],
       handle_begin: [_, :state],
-      handle_commit: [_, :new_state],
-      disconnect: [_, :newer_state],
+      disconnect: [_, :new_state],
       connect: [_]] = A.record(agent)
   end
 
-  test "transaction commit bad return raises and stops connection" do
+  test "run begin bad return raises and stops connection" do
     stack = [
       fn(opts) ->
         send(opts[:parent], {:hi, self()})
         Process.link(opts[:parent])
         {:ok, :state}
       end,
-      {:ok, :began, :new_state},
       :oops,
       {:ok, :state}
       ]
@@ -556,33 +399,36 @@ defmodule TransactionTest do
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
-    assert_receive {:hi, conn}
+    assert_receive {:hi, pid}
 
     Process.flag(:trap_exit, true)
-    assert_raise DBConnection.ConnectionError, "bad return value: :oops",
-      fn() -> P.transaction(pool, fn(_) -> :result end) end
+
+    assert P.run(pool, fn(conn) ->
+      assert_raise DBConnection.ConnectionError, "bad return value: :oops",
+        fn() -> P.begin(conn, opts) end
+
+      :hi
+    end) == :hi
 
     prefix = "client #{inspect self()} stopped: " <>
       "** (DBConnection.ConnectionError) bad return value: :oops"
     len = byte_size(prefix)
-    assert_receive {:EXIT, ^conn,
+    assert_receive {:EXIT, ^pid,
       {%DBConnection.ConnectionError{message: <<^prefix::binary-size(len), _::binary>>},
         [_|_]}}
 
     assert [
       {:connect, _},
-      {:handle_begin, [_, :state]},
-      {:handle_commit, [_, :new_state]} | _] = A.record(agent)
+      {:handle_begin, [_, :state]}| _] = A.record(agent)
   end
 
-  test "transaction commit raise raises and stops connection" do
+  test "run begin raise raises and stops connection" do
     stack = [
       fn(opts) ->
         send(opts[:parent], {:hi, self()})
         Process.link(opts[:parent])
         {:ok, :state}
       end,
-      {:ok, :began, :new_state},
       fn(_, _) ->
         raise "oops"
       end,
@@ -592,162 +438,194 @@ defmodule TransactionTest do
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
-    assert_receive {:hi, conn}
+    assert_receive {:hi, pid}
 
     Process.flag(:trap_exit, true)
-    assert_raise RuntimeError, "oops",
-      fn() -> P.transaction(pool, fn(_) -> :result end) end
+
+    assert P.run(pool, fn(conn) ->
+      assert_raise RuntimeError, "oops",
+        fn() -> P.begin(conn, opts) end
+
+      :hi
+    end) == :hi
 
     prefix = "client #{inspect self()} stopped: ** (RuntimeError) oops"
     len = byte_size(prefix)
-    assert_receive {:EXIT, ^conn,
+    assert_receive {:EXIT, ^pid,
       {%DBConnection.ConnectionError{message: <<^prefix::binary-size(len), _::binary>>},
        [_|_]}}
 
     assert [
       {:connect, _},
-      {:handle_begin, [_, :state]},
-      {:handle_commit, [_, :new_state]} | _] = A.record(agent)
+      {:handle_begin, [_, :state]} | _] = A.record(agent)
   end
 
-  test "transaction logs commit raise" do
-    stack = [
-      fn(opts) ->
-        Process.link(opts[:parent])
-        {:ok, :state}
-      end,
-      {:ok, :began, :new_state},
-      fn(_, _) ->
-        raise "oops"
-      end,
-      {:ok, :state2}
-      ]
-    {:ok, agent} = A.start_link(stack)
-
-    parent = self()
-    opts = [agent: agent, parent: parent]
-    _ = Process.flag(:trap_exit, true)
-    {:ok, pool} = P.start_link(opts)
-
-    log = &send(parent, &1)
-    assert_raise RuntimeError, "oops",
-      fn() ->
-        P.transaction(pool, fn(_) -> :ok end, [log: log])
-      end
-
-    assert_received %DBConnection.LogEntry{call: :transaction} = entry
-    assert %{query: :begin, params: nil, result: {:ok, :began}} = entry
-
-    assert_received %DBConnection.LogEntry{call: :transaction} = entry
-    assert %{query: :commit, params: nil, result: {:error, err}} = entry
-    assert %DBConnection.ConnectionError{message: "an exception was raised: ** (RuntimeError) oops" <> _} = err
-    assert is_nil(entry.pool_time)
-    assert is_integer(entry.connection_time)
-    assert entry.connection_time >= 0
-    assert is_nil(entry.decode_time)
-    assert_receive {:EXIT, _, {%DBConnection.ConnectionError{}, [_|_]}}
-
-    assert [
-      {:connect, [_]},
-      {:handle_begin, [_, :state]},
-      {:handle_commit, [_, :new_state]} | _] = A.record(agent)
-  end
-
-  test "transaction rollback error raises error" do
-    err = RuntimeError.exception("oops")
+  test "checkout_begin returns result and conn" do
     stack = [
       {:ok, :state},
       {:ok, :began, :new_state},
-      {:error, err, :newer_state},
-      {:ok, :began, :newest_state},
+      {:ok, :began, :newer_state}
+      ]
+    {:ok, agent} = A.start_link(stack)
+
+    opts = [agent: agent, parent: self()]
+    {:ok, pool} = P.start_link(opts)
+
+    assert {:ok, conn, :began} = P.checkout_begin(pool, opts)
+    assert P.checkin(conn, opts) == :ok
+
+
+    opts2 = [key: :value] ++ opts
+    assert {:ok, conn, :began} = P.checkout_begin(pool, opts2)
+    assert P.checkin(conn, opts) == :ok
+
+    assert [
+      connect: [_],
+      handle_begin: [ _, :state],
+      handle_begin: [[{:key, :value} | _], :new_state],
+    ] = A.record(agent)
+  end
+
+  test "commit_checkin returns result" do
+    stack = [
+      {:ok, :state},
+      {:ok, :committed, :new_state},
+      {:ok, :committed, :newer_state}
+      ]
+    {:ok, agent} = A.start_link(stack)
+
+    opts = [agent: agent, parent: self()]
+    {:ok, pool} = P.start_link(opts)
+
+    assert {:ok, conn} = P.checkout(pool, opts)
+    assert P.commit_checkin(conn, opts) == {:ok, :committed}
+
+
+    opts2 = [key: :value] ++ opts
+    assert {:ok, conn} = P.checkout(pool, opts2)
+    assert P.commit_checkin(conn, opts2) == {:ok, :committed}
+
+    assert [
+      connect: [_],
+      handle_commit: [ _, :state],
+      handle_commit: [[{:key, :value} | _], :new_state],
+    ] = A.record(agent)
+  end
+
+  test "rollback_checkin returns result" do
+    stack = [
+      {:ok, :state},
+      {:ok, :rolledback, :new_state},
+      {:ok, :rolledback, :newer_state}
+      ]
+    {:ok, agent} = A.start_link(stack)
+
+    opts = [agent: agent, parent: self()]
+    {:ok, pool} = P.start_link(opts)
+
+    assert {:ok, conn} = P.checkout(pool, opts)
+    assert P.rollback_checkin(conn, opts) == {:ok, :rolledback}
+
+
+    opts2 = [key: :value] ++ opts
+    assert {:ok, conn} = P.checkout(pool, opts2)
+    assert P.rollback_checkin(conn, opts2) == {:ok, :rolledback}
+
+    assert [
+      connect: [_],
+      handle_rollback: [ _, :state],
+      handle_rollback: [[{:key, :value} | _], :new_state],
+    ] = A.record(agent)
+  end
+
+  test "checkout_begin/commit_checkin/rollback_checkin log results" do
+    stack = [
+      {:ok, :state},
+      {:ok, :began, :new_state},
+      {:ok, :committed, :newer_state},
       {:ok, :rolledback, :newest_state}
       ]
     {:ok, agent} = A.start_link(stack)
 
-    opts = [agent: agent, parent: self()]
-    {:ok, pool} = P.start_link(opts)
-
-    assert_raise RuntimeError, "oops",
-      fn() -> P.transaction(pool, &P.rollback(&1, :oops)) end
-
-    assert P.transaction(pool, fn(_) -> :result end) == {:ok, :result}
-
-    assert [
-      connect: [_],
-      handle_begin: [_, :state],
-      handle_rollback: [_, :new_state],
-      handle_begin: [_, :newer_state],
-      handle_commit: [_, :newest_state]] = A.record(agent)
-  end
-
-  test "transaction fun raise rolls back and re-raises" do
-   stack = [
-      {:ok, :state},
-      {:ok, :began, :new_state},
-      {:ok, :rolledback, :newer_state},
-      ]
-    {:ok, agent} = A.start_link(stack)
-
-    opts = [agent: agent, parent: self()]
-    {:ok, pool} = P.start_link(opts)
-
-    assert_raise RuntimeError, "oops",
-      fn() -> P.transaction(pool, fn(_) -> raise "oops"end) end
-
-    assert [
-      connect: [_],
-      handle_begin: [_, :state],
-      handle_rollback: [_, :new_state]] = A.record(agent)
-  end
-
-  test "transaction logs rollback raise" do
-    stack = [
-      fn(opts) ->
-        Process.link(opts[:parent])
-        {:ok, :state}
-      end,
-      {:ok, :began, :new_state},
-      fn(_, _) ->
-        raise "oops"
-      end,
-      {:ok, :state2}
-      ]
-    {:ok, agent} = A.start_link(stack)
-
     parent = self()
     opts = [agent: agent, parent: parent]
-    _ = Process.flag(:trap_exit, true)
     {:ok, pool} = P.start_link(opts)
 
     log = &send(parent, &1)
-    assert_raise RuntimeError, "oops",
-      fn() ->
-        P.transaction(pool, &P.rollback(&1, :oops), [log: log])
-      end
 
-    assert_received %DBConnection.LogEntry{call: :transaction} = entry
-    assert %{query: :begin, params: nil, result: {:ok, :began}} = entry
+    assert {:ok, conn, :began} = P.checkout_begin(pool, [log: log] ++ opts)
 
-    assert_received %DBConnection.LogEntry{call: :transaction} = entry
-    assert %{query: :rollback, params: nil, result: {:error, err}} = entry
-    assert %DBConnection.ConnectionError{message: "an exception was raised: ** (RuntimeError) oops" <> _} = err
+    assert_received %DBConnection.LogEntry{call: :checkout_begin} = entry
+    assert %{query: :begin, params: nil, result: {:ok, ^conn, :began}} = entry
+    assert is_integer(entry.pool_time)
+    assert entry.pool_time >= 0
+    assert is_integer(entry.connection_time)
+    assert entry.connection_time >= 0
+    assert is_nil(entry.decode_time)
+
+    assert P.commit_checkin(conn, [log: log] ++ opts) == {:ok, :committed}
+
+    assert_received %DBConnection.LogEntry{call: :commit_checkin} = entry
+    assert %{query: :commit, params: nil, result: {:ok, :committed}} = entry
     assert is_nil(entry.pool_time)
     assert is_integer(entry.connection_time)
     assert entry.connection_time >= 0
     assert is_nil(entry.decode_time)
-    assert_receive {:EXIT, _, {%DBConnection.ConnectionError{}, [_|_]}}
+
+    assert {:ok, conn} = P.checkout(pool, opts)
+
+    assert P.rollback_checkin(conn, [log: log] ++ opts) == {:ok, :rolledback}
+
+    assert_received %DBConnection.LogEntry{call: :rollback_checkin} = entry
+    assert %{query: :rollback, params: nil, result: {:ok, :rolledback}} = entry
+    assert is_nil(entry.pool_time)
+    assert is_integer(entry.connection_time)
+    assert entry.connection_time >= 0
+    assert is_nil(entry.decode_time)
 
     assert [
-      {:connect, [_]},
-      {:handle_begin, [_, :state]},
-      {:handle_rollback, [_, :new_state]} | _] = A.record(agent)
+      connect: [_],
+      handle_begin: [ _, :state],
+      handle_commit: [_, :new_state],
+      handle_rollback: [_, :newer_state]] = A.record(agent)
   end
 
-  test "transaction logs on fun raise" do
-   stack = [
+  test "checkout_begin!/commit_checkin!/rollback_checkin! error raises error" do
+    err = RuntimeError.exception("oops")
+    stack = [
       {:ok, :state},
-      {:ok, :began, :new_state},
-      {:ok, :rolledback, :newer_state},
+      {:error, err, :new_state},
+      {:error, err, :newer_state},
+      {:error, err, :newest_state}
+      ]
+    {:ok, agent} = A.start_link(stack)
+
+    opts = [agent: agent, parent: self()]
+    {:ok, pool} = P.start_link(opts)
+
+    assert_raise RuntimeError, "oops", fn() -> P.checkout_begin!(pool, opts) end
+
+    assert {:ok, conn} = P.checkout(pool, opts)
+    assert_raise RuntimeError, "oops", fn() -> P.commit!(conn, opts) end
+    assert_raise RuntimeError, "oops", fn() -> P.rollback!(conn, opts) end
+
+    assert :ok = P.checkin(conn, opts)
+
+    assert [
+      connect: [_],
+      handle_begin: [ _, :state],
+      handle_commit: [_, :new_state],
+      handle_rollback: [_, :newer_state]
+      ] = A.record(agent)
+  end
+
+  test "checkout_begin/checkout_commit/checkout_rollback logs error" do
+    err = RuntimeError.exception("oops")
+    stack = [
+      {:ok, :state},
+      {:error, err, :new_state},
+      {:error, err, :newer_state},
+      {:error, err, :newest_state}
       ]
     {:ok, agent} = A.start_link(stack)
 
@@ -757,20 +635,229 @@ defmodule TransactionTest do
 
     log = &send(parent, &1)
 
-    assert_raise RuntimeError, "oops",
-      fn() ->
-        P.transaction(pool, fn(_) ->
-          assert_received %DBConnection.LogEntry{call: :transaction,
-            query: :begin}
-          raise "oops"
-        end, [log: log])
-      end
+    assert P.checkout_begin(pool, [log: log] ++ opts) == {:error, err}
 
-    assert_received %DBConnection.LogEntry{call: :transaction, query: :rollback}
+    assert_received %DBConnection.LogEntry{call: :checkout_begin} = entry
+    assert %{query: :begin, params: nil, result: {:error, ^err}} = entry
+    assert is_integer(entry.pool_time)
+    assert entry.pool_time >= 0
+    assert is_integer(entry.connection_time)
+    assert entry.connection_time >= 0
+    assert is_nil(entry.decode_time)
+
+    assert {:ok, conn} = P.checkout(pool, opts)
+    assert P.commit_checkin(conn, [log: log] ++ opts) == {:error, err}
+
+    assert_received %DBConnection.LogEntry{call: :commit_checkin} = entry
+    assert %{query: :commit, params: nil, result: {:error, ^err}} = entry
+    assert is_nil(entry.pool_time)
+    assert is_integer(entry.connection_time)
+    assert entry.connection_time >= 0
+    assert is_nil(entry.decode_time)
+
+    assert P.rollback_checkin(conn, [log: log] ++ opts) == {:error, err}
+
+    assert_received %DBConnection.LogEntry{call: :rollback_checkin} = entry
+    assert %{query: :rollback, params: nil, result: {:error, ^err}} = entry
+    assert is_nil(entry.pool_time)
+    assert is_integer(entry.connection_time)
+    assert entry.connection_time >= 0
+    assert is_nil(entry.decode_time)
+
+    assert :ok = P.checkin(conn, opts)
 
     assert [
       connect: [_],
       handle_begin: [_, :state],
-      handle_rollback: [_, :new_state]] = A.record(agent)
+      handle_commit: [_, :new_state],
+      handle_rollback: [_, :newer_state]
+      ] = A.record(agent)
+  end
+
+  test "checkout_begin! disconnect raises error" do
+    err = RuntimeError.exception("oops")
+    stack = [
+      {:ok, :state},
+      {:disconnect, err, :new_state},
+      :ok,
+      fn(opts) ->
+        send(opts[:parent], :reconnected)
+        {:ok, :newest_state}
+      end
+      ]
+    {:ok, agent} = A.start_link(stack)
+
+    opts = [agent: agent, parent: self()]
+    {:ok, pool} = P.start_link(opts)
+
+    assert_raise RuntimeError, "oops", fn() -> P.checkout_begin!(pool, opts) end
+
+    assert_receive :reconnected
+
+    assert [
+      connect: [_],
+      handle_begin: [_, :state],
+      disconnect: [_, :new_state],
+      connect: [_]] = A.record(agent)
+  end
+
+  test "commit_checkin! disconnect raises error" do
+    err = RuntimeError.exception("oops")
+    stack = [
+      {:ok, :state},
+      {:disconnect, err, :new_state},
+      :ok,
+      fn(opts) ->
+        send(opts[:parent], :reconnected)
+        {:ok, :newest_state}
+      end
+      ]
+    {:ok, agent} = A.start_link(stack)
+
+    opts = [agent: agent, parent: self()]
+    {:ok, pool} = P.start_link(opts)
+
+    {:ok, conn} = P.checkout(pool, opts)
+    assert_raise RuntimeError, "oops", fn() -> P.commit_checkin!(conn, opts) end
+
+    assert_receive :reconnected
+
+    assert [
+      connect: [_],
+      handle_commit: [_, :state],
+      disconnect: [_, :new_state],
+      connect: [_]] = A.record(agent)
+  end
+
+  test "checkout_begin bad return raises and stops connection" do
+    stack = [
+      fn(opts) ->
+        send(opts[:parent], {:hi, self()})
+        Process.link(opts[:parent])
+        {:ok, :state}
+      end,
+      :oops,
+      {:ok, :state}
+      ]
+    {:ok, agent} = A.start_link(stack)
+
+    opts = [agent: agent, parent: self()]
+    {:ok, pool} = P.start_link(opts)
+    assert_receive {:hi, pid}
+
+    Process.flag(:trap_exit, true)
+    assert_raise DBConnection.ConnectionError, "bad return value: :oops",
+      fn() -> P.checkout_begin(pool, opts) end
+
+    prefix = "client #{inspect self()} stopped: " <>
+      "** (DBConnection.ConnectionError) bad return value: :oops"
+    len = byte_size(prefix)
+    assert_receive {:EXIT, ^pid,
+      {%DBConnection.ConnectionError{message: <<^prefix::binary-size(len), _::binary>>},
+        [_|_]}}
+
+    assert [
+      {:connect, _},
+      {:handle_begin, [_, :state]}| _] = A.record(agent)
+  end
+
+  test "rollback_checkin bad return raises and stops connection" do
+    stack = [
+      fn(opts) ->
+        send(opts[:parent], {:hi, self()})
+        Process.link(opts[:parent])
+        {:ok, :state}
+      end,
+      :oops,
+      {:ok, :state}
+      ]
+    {:ok, agent} = A.start_link(stack)
+
+    opts = [agent: agent, parent: self()]
+    {:ok, pool} = P.start_link(opts)
+    assert_receive {:hi, pid}
+
+    assert {:ok, conn} = P.checkout(pool, opts)
+    Process.flag(:trap_exit, true)
+    assert_raise DBConnection.ConnectionError, "bad return value: :oops",
+      fn() -> P.rollback_checkin(conn, opts) end
+
+    prefix = "client #{inspect self()} stopped: " <>
+      "** (DBConnection.ConnectionError) bad return value: :oops"
+    len = byte_size(prefix)
+    assert_receive {:EXIT, ^pid,
+      {%DBConnection.ConnectionError{message: <<^prefix::binary-size(len), _::binary>>},
+        [_|_]}}
+
+    assert [
+      {:connect, _},
+      {:handle_rollback, [_, :state]}| _] = A.record(agent)
+  end
+
+  test "checkout_begin raise raises and stops connection" do
+    stack = [
+      fn(opts) ->
+        send(opts[:parent], {:hi, self()})
+        Process.link(opts[:parent])
+        {:ok, :state}
+      end,
+      fn(_, _) ->
+        raise "oops"
+      end,
+      {:ok, :state}
+      ]
+    {:ok, agent} = A.start_link(stack)
+
+    opts = [agent: agent, parent: self()]
+    {:ok, pool} = P.start_link(opts)
+    assert_receive {:hi, pid}
+
+    Process.flag(:trap_exit, true)
+    assert_raise RuntimeError, "oops",
+      fn() -> P.checkout_begin(pool, opts) end
+
+    prefix = "client #{inspect self()} stopped: ** (RuntimeError) oops"
+    len = byte_size(prefix)
+    assert_receive {:EXIT, ^pid,
+      {%DBConnection.ConnectionError{message: <<^prefix::binary-size(len), _::binary>>},
+       [_|_]}}
+
+    assert [
+      {:connect, _},
+      {:handle_begin, [_, :state]} | _] = A.record(agent)
+  end
+
+  test "commit_checkin raise raises and stops connection" do
+    stack = [
+      fn(opts) ->
+        send(opts[:parent], {:hi, self()})
+        Process.link(opts[:parent])
+        {:ok, :state}
+      end,
+      fn(_, _) ->
+        raise "oops"
+      end,
+      {:ok, :state}
+      ]
+    {:ok, agent} = A.start_link(stack)
+
+    opts = [agent: agent, parent: self()]
+    {:ok, pool} = P.start_link(opts)
+    assert_receive {:hi, pid}
+
+    assert {:ok, conn} = P.checkout(pool, opts)
+    Process.flag(:trap_exit, true)
+    assert_raise RuntimeError, "oops",
+      fn() -> P.commit_checkin(conn, opts) end
+
+    prefix = "client #{inspect self()} stopped: ** (RuntimeError) oops"
+    len = byte_size(prefix)
+    assert_receive {:EXIT, ^pid,
+      {%DBConnection.ConnectionError{message: <<^prefix::binary-size(len), _::binary>>},
+       [_|_]}}
+
+    assert [
+      {:connect, _},
+      {:handle_commit, [_, :state]} | _] = A.record(agent)
   end
 end

--- a/integration_test/tests.exs
+++ b/integration_test/tests.exs
@@ -9,6 +9,6 @@ Code.require_file "cases/prepare_execute_test.exs", __DIR__
 Code.require_file "cases/prepare_stream_test.exs", __DIR__
 Code.require_file "cases/prepare_test.exs", __DIR__
 Code.require_file "cases/queue_test.exs", __DIR__
+Code.require_file "cases/run_test.exs", __DIR__
 Code.require_file "cases/stream_test.exs", __DIR__
-Code.require_file "cases/transaction_execute_test.exs", __DIR__
 Code.require_file "cases/transaction_test.exs", __DIR__

--- a/test/test_support.exs
+++ b/test/test_support.exs
@@ -15,11 +15,13 @@ defmodule TestConnection do
         DBConnection.run(pool, fun, opts2 ++ unquote(opts))
       end
 
-      def transaction(pool, fun, opts2 \\ []) do
-        DBConnection.transaction(pool, fun, opts2 ++ unquote(opts))
+      def checkout(pool, opts2 \\ []) do
+        DBConnection.checkout(pool, opts2 ++ unquote(opts))
       end
 
-      defdelegate rollback(conn, reason), to: DBConnection
+      def checkin(conn, opts2 \\ []) do
+        DBConnection.checkin(conn, opts2 ++ unquote(opts))
+      end
 
       def prepare(pool, query, opts2 \\ []) do
         DBConnection.prepare(pool, query, opts2 ++ unquote(opts))
@@ -61,6 +63,54 @@ defmodule TestConnection do
 
       def close!(pool, query, opts2 \\ []) do
         DBConnection.close!(pool, query, opts2 ++ unquote(opts))
+      end
+
+      def begin(pool, opts2 \\ []) do
+        DBConnection.begin(pool, opts2 ++ unquote(opts))
+      end
+
+      def begin!(pool, opts2 \\ []) do
+        DBConnection.begin!(pool, opts2 ++ unquote(opts))
+      end
+
+      def commit(pool, opts2 \\ []) do
+        DBConnection.commit(pool, opts2 ++ unquote(opts))
+      end
+
+      def commit!(pool, opts2 \\ []) do
+        DBConnection.commit!(pool, opts2 ++ unquote(opts))
+      end
+
+      def rollback(pool, opts2 \\ []) do
+        DBConnection.rollback(pool, opts2 ++ unquote(opts))
+      end
+
+      def rollback!(pool, opts2 \\ []) do
+        DBConnection.rollback!(pool, opts2 ++ unquote(opts))
+      end
+
+      def checkout_begin(pool, opts2 \\ []) do
+        DBConnection.checkout_begin(pool, opts2 ++ unquote(opts))
+      end
+
+      def checkout_begin!(pool, opts2 \\ []) do
+        DBConnection.checkout_begin!(pool, opts2 ++ unquote(opts))
+      end
+
+      def commit_checkin(pool, opts2 \\ []) do
+        DBConnection.commit_checkin(pool, opts2 ++ unquote(opts))
+      end
+
+      def commit_checkin!(pool, opts2 \\ []) do
+        DBConnection.commit_checkin!(pool, opts2 ++ unquote(opts))
+      end
+
+      def rollback_checkin(pool, opts2 \\ []) do
+        DBConnection.rollback_checkin(pool, opts2 ++ unquote(opts))
+      end
+
+      def rollback_checkin!(pool, opts2 \\ []) do
+        DBConnection.rollback_checkin!(pool, opts2 ++ unquote(opts))
       end
 
       defoverridable [start_link: 1]


### PR DESCRIPTION
Requiring a fun for a transaction and non-local return for a rollback
is a very limiting API. With this breaking change the API becomes more
flexible, in particular it allows transaction to continue over multiple
OTP behaviour callbacks and use of (potentially nested) savepoints.

Removes:
* DBConnection.transaction/3
* DBConnection.rollback/2

Adds:
* DBConnection.checkout/2
* DBConnection.checkin/2
* DBConnection.begin/2
* DBConnection.commit/2
* DBConnection.rollback/2
* DBConnection.checkout_begin/2
* DBConnection.commit_checkin/2
* DBConnection.rollback_checkin/2