### PR TITLE
Allow execute to prepare new query

### DIFF
--- a/test/test_support.exs
+++ b/test/test_support.exs
@@ -213,9 +213,13 @@ defimpl DBConnection.Query, for: TestQuery do
     encode.(params)
   end
 
-  def decode(_, result, opts) do
-    decode = Keyword.get(opts, :decode, &(&1))
-    decode.(result)
+  def decode(query, result, opts) do
+    case Keyword.get(opts, :decode, &(&1)) do
+      decode when is_function(decode, 1) ->
+        decode.(result)
+      decode when is_function(decode, 2) ->
+        decode.(query, result)
+    end
   end
 end
 


### PR DESCRIPTION
This change will allow us to cast parameters if the parameter types have changed when executing a query that has not been prepared on a connection, decode using the new result types. This will allow us more chances not to error in Ecto when a migration occurs live.