### PR TITLE
Add built in connection pool

### DIFF
--- a/integration_test/cases/idle_test.exs
+++ b/integration_test/cases/idle_test.exs
@@ -28,7 +28,7 @@ defmodule TestIdle do
       end]
     {:ok, agent} = A.start_link(stack)
 
-    opts = [agent: agent, parent: self(), idle_timeout: 50]
+    opts = [agent: agent, parent: self(), idle_timeout: 50, idle_interval: 50]
     {:ok, pool} = P.start_link(opts)
     assert_receive {:hi, conn}
     assert_receive {:pong, ^conn}

--- a/integration_test/cases/queue_test.exs
+++ b/integration_test/cases/queue_test.exs
@@ -42,7 +42,8 @@ defmodule QueueTest do
     stack = [{:ok, :state}]
     {:ok, agent} = A.start_link(stack)
 
-    opts = [agent: agent, parent: self(), queue_timeout: 50]
+    opts = [agent: agent, parent: self(), queue_timeout: 50, queue_target: 50,
+      queue_interval: 50]
     {:ok, pool} = P.start_link(opts)
 
     parent = self()
@@ -58,7 +59,7 @@ defmodule QueueTest do
 
     run = fn() ->
       try do
-        P.run(pool, fn(_) -> flunk("run ran") end, [pool_timeout: 50, timeout: 50])
+        P.run(pool, fn(_) -> flunk("run ran") end, [pool_timeout: 50])
       rescue
         DBConnection.ConnectionError ->
           :error
@@ -147,7 +148,8 @@ defmodule QueueTest do
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self(), backoff_start: 30_000,
-      queue_timeout: 10, pool_timeout: 10]
+      queue_timeout: 10, pool_timeout: 10, queue_target: 10,
+      queue_interval: 10]
     {:ok, pool} = P.start_link(opts)
 
     P.run(pool, fn(_) ->
@@ -165,7 +167,7 @@ defmodule QueueTest do
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self(), backoff_start: 30_000,
-      queue_timeout: 10, pool_timeout: 10, timeout: 10]
+      queue_timeout: 10, pool_timeout: 10, queue_target: 10, queue_interval: 10]
     {:ok, pool} = P.start_link(opts)
 
     P.run(pool, fn(_) ->

--- a/integration_test/cases/queue_test.exs
+++ b/integration_test/cases/queue_test.exs
@@ -58,7 +58,7 @@ defmodule QueueTest do
 
     run = fn() ->
       try do
-        P.run(pool, fn(_) -> flunk("run ran") end, [pool_timeout: 50])
+        P.run(pool, fn(_) -> flunk("run ran") end, [pool_timeout: 50, timeout: 50])
       rescue
         DBConnection.ConnectionError ->
           :error
@@ -165,7 +165,7 @@ defmodule QueueTest do
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self(), backoff_start: 30_000,
-      queue_timeout: 10, pool_timeout: 10]
+      queue_timeout: 10, pool_timeout: 10, timeout: 10]
     {:ok, pool} = P.start_link(opts)
 
     P.run(pool, fn(_) ->

--- a/integration_test/connection_pool/all_test.exs
+++ b/integration_test/connection_pool/all_test.exs
@@ -1,0 +1,1 @@
+Code.require_file "../tests.exs", __DIR__

--- a/integration_test/connection_pool/test_helper.exs
+++ b/integration_test/connection_pool/test_helper.exs
@@ -1,0 +1,11 @@
+ExUnit.start([capture_log: true, assert_receive_timeout: 500,
+              exclude: [:idle_timeout, :pool_overflow, :enqueue_disconnected,
+                        :queue_timeout_exit]])
+
+Code.require_file "../../test/test_support.exs", __DIR__
+
+defmodule TestPool do
+  use TestConnection, [pool: DBConnection.ConnectionPool, pool_size: 1]
+end
+
+{:ok, _} = TestPool.ensure_all_started()

--- a/integration_test/connection_pool/test_helper.exs
+++ b/integration_test/connection_pool/test_helper.exs
@@ -1,5 +1,5 @@
 ExUnit.start([capture_log: true, assert_receive_timeout: 500,
-              exclude: [:idle_timeout, :pool_overflow, :enqueue_disconnected,
+              exclude: [:pool_overflow, :enqueue_disconnected,
                         :queue_timeout_exit]])
 
 Code.require_file "../../test/test_support.exs", __DIR__

--- a/lib/db_connection/app.ex
+++ b/lib/db_connection/app.ex
@@ -9,6 +9,7 @@ defmodule DBConnection.App do
       supervisor(DBConnection.Task, []),
       supervisor(DBConnection.Sojourn.Supervisor, []),
       supervisor(DBConnection.Ownership.PoolSupervisor, []),
+      supervisor(DBConnection.ConnectionPool.PoolSupervisor, []),
       worker(DBConnection.Watcher, [])
     ]
     Supervisor.start_link(children, strategy: :one_for_all, name: __MODULE__)

--- a/lib/db_connection/connection_pool.ex
+++ b/lib/db_connection/connection_pool.ex
@@ -176,7 +176,7 @@ defmodule DBConnection.ConnectionPool do
         {sent, _} = key when sent <= last_sent and status == :ready ->
             ping(key, queue, start_idle(time, last_sent, codel))
         {sent, _} ->
-            {:noreply, {:ready, queue, start_idle(time, sent, codel)}}
+            {:noreply, {status, queue, start_idle(time, sent, codel)}}
         :"$end_of_table" ->
             {:noreply, {status, queue, start_idle(time, time, codel)}}
     end

--- a/lib/db_connection/connection_pool.ex
+++ b/lib/db_connection/connection_pool.ex
@@ -1,0 +1,341 @@
+defmodule DBConnection.ConnectionPool do
+
+  alias DBConnection.Ownership.PoolSupervisor
+
+  @behaviour DBConnection.Pool
+  use GenServer
+
+  @timeout 5000
+  @queue true
+  @queue_target 50
+  @queue_interval 1000
+
+  ## DBConnection.Pool API
+
+  @doc false
+  def ensure_all_started(_opts, _type) do
+    {:ok, []}
+  end
+
+  @doc false
+  def start_link(mod, opts) do
+    GenServer.start_link(__MODULE__, {mod, opts}, start_opts(opts))
+  end
+
+  @doc false
+  def child_spec(mod, opts, child_opts \\ []) do
+    Supervisor.Spec.worker(__MODULE__, [mod, opts], child_opts)
+  end
+
+  @doc false
+  def checkout(pool, opts) do
+    now = System.monotonic_time(:milliseconds)
+    with pid when node(pid) == node() <- GenServer.whereis(pool) do
+      queue? = Keyword.get(opts, :queue, @queue)
+      # Technically its possible for caller to exit between starting
+      # timer and sending message in call. This leaks the timer but should
+      # be so rare and last a very short time period.
+      deadline = start_deadline(pid, now, opts)
+      try do
+        GenServer.call(pid, {:checkout, now, queue?, deadline}, :infinity)
+      catch
+        :exit, {reason, {:gen_statem, :call, [^pid | _]}} ->
+          exit({reason, {__MODULE__, :checkout, [pool, opts]}})
+      end
+    else
+      nil ->
+        exit({:noproc, {__MODULE__, :checkout, [pool, opts]}})
+      {_, node} ->
+        exit({{:badnode, node}, {__MODULE__, :checkout, [pool, opts]}})
+      pid ->
+        exit({{:badnode, node(pid)}, {__MODULE__, :checkout, [pool, opts]}})
+    end
+  end
+
+  @doc false
+  def checkin({pid, {deadline, mon}}, conn, _) do
+    cancel_deadline(deadline)
+    now = System.monotonic_time(:milliseconds)
+    GenServer.cast(pid, {:checkin, now, mon, conn})
+  end
+
+  @doc false
+  def disconnect({pid, {deadline, mon}}, err, conn, _) do
+    cancel_deadline(deadline)
+    GenServer.cast(pid, {:disconnect, mon, err, conn})
+  end
+
+  @doc false
+  def stop({pid, {deadline, mon}}, err, conn, _) do
+    cancel_deadline(deadline)
+    GenServer.cast(pid, {:stop, mon, err, conn})
+  end
+
+  ## GenServer api
+    
+  def init({mod, opts}) do
+    queue = :ets.new(__MODULE__, [:private, :ordered_set])
+    {:ok, pool, _} = PoolSupervisor.start_pool(mod, pool_opts(opts, queue))
+    target = Keyword.get(opts, :queue_target, @queue_target)
+    interval = Keyword.get(opts, :queue_interval, @queue_interval)
+    state = %{queue: queue, pool: pool, target: target, interval: interval,
+              delay: 0, slow: false, next: System.monotonic_time(:milliseconds),
+              client: nil, conn: nil}
+    {:ok, state}
+  end
+
+  def handle_call({:checkout, time, queue?, deadline}, {pid, _} = from, s) do
+    case s do
+      %{client: nil, conn: {:ok, _pool_ref, _mod, _state} = conn} ->
+        client = {deadline, Process.monitor(pid)}
+        {:reply, put_elem(conn, 1, {self(), client}), %{s | client: client}}
+      %{client: nil, conn: {:error, _} = error} ->
+        cancel_deadline(deadline)
+        {:reply, error, s}
+      %{queue: queue} when queue? == true ->
+        client = {deadline, Process.monitor(pid)}
+        # from is {pid, ref} so order could favor certain pid(s)
+        :ets.insert(queue, {{time, from}, client})
+        {:noreply, s}
+      s when queue? == false ->
+        message = "connection not available and queuing is disabled"
+        err = DBConnection.ConnectionError.exception(message)
+        {:reply, {:error, err}, s}
+    end
+  end
+
+  def handle_cast({:checkin, time, mon, state}, s) do
+    case s do
+      %{client: {_deadline, ^mon}, conn: {:ok, _pool_ref, _mod, _state} = conn} ->
+        result = dequeue(time, put_elem(conn, 3, state), s)
+        Process.demonitor(mon, [:flush])
+        result
+      %{} ->
+        {:noreply, s}
+    end
+  end
+
+  def handle_cast({:disconnect, mon, err, state}, s) do
+    abort(&DBConnection.Connection.disconnect/4, mon, err, state, s)
+  end
+
+  def handle_cast({:stop, mon, err, state}, s) do
+    abort(&DBConnection.Connection.stop/4, mon, err, state, s)
+  end
+
+  def handle_cast({:connected, time, queue}, %{queue: queue, conn: conn} = s)
+      when conn == nil or elem(conn, 0) == :error do
+    # TODO: connection process must send the state async so that pool never blocks.
+    case DBConnection.Connection.checkout(s.pool, [queue: false, timeout: :infinity]) do
+      {:ok, _pool_ref, _mod, _state} = conn ->
+        dequeue(time, conn, %{s | conn: conn})
+      {:error, _} = error ->
+        error(queue, error)
+        {:noreply, %{s | conn: error}}
+    end
+  end
+
+  def handle_info({:DOWN, mon, _, pid, reason}, s) do
+    case s do
+      %{client: {deadline, ^mon}} ->
+        cancel_deadline(deadline)
+        message = "client #{inspect pid} exited with: " <> Exception.format_exit(reason)
+        err = DBConnection.ConnectionError.exception(message)
+        fail(err, s)
+      %{} ->
+        down(mon, s)
+    end
+  end
+
+  def handle_info({:timeout, deadline, {pid, sent, time}}, s) do
+    case s do
+      %{client: {^deadline, mon}} ->
+        Process.demonitor(mon, [:flush])
+        message = "client #{inspect pid} timed out because " <>
+            "it queued and checked out the connection for longer than #{time-sent}ms"
+        err = DBConnection.ConnectionError.exception(message)
+        fail(err, s)
+      %{} ->
+        timeout(deadline, sent, time, s)
+    end
+  end
+
+  defp dequeue(time, conn, s) do
+    case s do
+      %{next: next, delay: delay, target: target} when time > next  ->
+        dequeue_first(time, delay > target, conn, s)
+      %{slow: false, queue: queue, delay: delay} ->
+        dequeue_fast(time, queue, delay, conn, s)
+      %{slow: true, queue: queue, delay: delay, target: target} ->
+        dequeue_slow(time, queue, delay, target * 2, conn, s)
+    end
+  end
+
+  defp dequeue_first(time, slow?, conn, s) do
+    %{queue: queue, interval: interval} = s
+    next = time + interval
+    case :ets.first(queue) do
+      {sent, from} = key ->
+        client = go(queue, key, from, conn)
+        delay = time - sent
+        {:noreply, %{s | next: next, delay: delay, slow: slow?, client: client,
+                         conn: conn}}
+      :"$end_of_table" ->
+        {:noreply, %{s | next: next, delay: 0, slow: slow?, client: nil,
+                         conn: conn}}
+    end
+  end
+
+  defp dequeue_fast(time, queue, delay, conn, s) do
+    case :ets.first(queue) do
+      {sent, from} = key ->
+        delay = min(time - sent, delay)
+        client = go(queue, key, from, conn)
+        {:noreply, %{s | delay: delay, client: client, conn: conn}}
+      :"$end_of_table" ->
+        {:noreply, %{s | delay: 0, client: nil, conn: conn}}
+    end     
+  end
+
+  defp dequeue_slow(time, queue, min_delay, timeout, conn, s) do
+    with {sent, from} = key <- :ets.first(queue) do
+      case time - sent do
+        delay when delay > timeout ->
+          drop(queue, key, from, delay)
+          dequeue_slow(time, queue, min(delay, min_delay), timeout, conn, s)
+        delay ->
+          client = go(queue, key, from, conn)
+          {:noreply, %{s | delay: min(delay, min_delay), client: client,
+                           conn: conn}}
+        end
+    else
+      :"$end_of_table" ->
+        {:noreply, %{s | delay: 0, client: nil, conn: conn}}
+    end
+  end
+
+  defp go(queue, key, from, conn) do
+    [{_, client}] = :ets.take(queue, key)
+    GenServer.reply(from, put_elem(conn, 1, {self(), client}))
+    client
+  end
+
+  defp drop(queue, key, from, sojourn) do
+    message = "connection not available " <>
+      "and request was dropped from queue after #{sojourn}ms"
+    err = DBConnection.ConnectionError.exception(message)
+    error(queue, key, from, err)
+  end
+  
+  defp error(queue, key, from, err) do
+    [{_, {deadline, mon}}] = :ets.take(queue, key)
+    GenServer.reply(from, {:error, err})
+    Process.demonitor(mon, [:flush])
+    cancel_deadline(deadline)
+  end
+
+  defp error(queue, err) do
+    case :ets.first(queue) do
+      {_, from} = key ->
+        error(queue, key, from, err)
+      :"$end_of_table" ->
+        :ok
+    end
+  end
+
+  defp abort(fun, mon, err, state, s) do
+    case s do
+      %{client: {_deadline, ^mon}, conn: {:ok, pool_ref, _, _}} ->
+        Process.demonitor(mon, [:flush])
+        fun.(pool_ref, err, state, [])
+        {:noreply, %{s | client: nil, conn: nil}}
+      %{} ->
+        {:noreply, s}
+    end
+  end
+
+  defp fail(err, %{conn: {:ok, pool_ref, _, state}} = s) do
+    DBConnection.Connection.disconnect(pool_ref, err, state, [])
+    {:noreply, %{s | client: nil, conn: nil}}
+  end
+
+  defp down(mon, %{queue: queue} = s) do
+    case :ets.match_object(queue, {:_, {:_, mon}}, 1) do
+      {[{key, {deadline, _}}], _cont} ->
+        cancel_deadline(deadline)
+        :ets.delete(queue, key)
+        {:noreply, s}
+      :"$end_of_table"->
+        {:noreply, s}
+    end
+  end
+
+  defp timeout(deadline, sent, time, %{queue: queue} = s) do
+    case :ets.match_object(queue, {{sent, :_}, {deadline, :_}}) do
+      [{{_, from} = key, {_, mon}}] ->
+        message = "connection not available " <>
+          "and request was dropped from queue after #{time-sent}ms"
+        err = DBConnection.ConnectionError.exception(message)
+        GenServer.reply(from, {:error, err})
+        Process.demonitor(mon, [:flush])
+        :ets.delete(queue, key)
+        {:noreply, s}
+      [] ->
+        {:noreply, s}
+    end
+  end
+
+  defp start_opts(opts) do
+    Keyword.take(opts, [:name, :spawn_opt])
+  end
+
+  defp start_deadline(pid, now, opts) do
+    case abs_timeout(now, opts) do
+      nil ->
+        nil
+      timeout ->
+        :erlang.start_timer(timeout, pid, {self(), now, timeout}, [abs: true])
+    end
+  end
+
+  defp abs_timeout(now, opts) do
+    case Keyword.get(opts, :timeout, @timeout) do
+      :infinity ->
+        Keyword.get(opts, :deadline)
+      timeout ->
+        min(now + timeout, Keyword.get(opts, :deadline))
+    end
+  end
+
+  defp cancel_deadline(deadline) do
+    :erlang.cancel_timer(deadline, [async: true, info: false])
+  end
+
+  defp pool_opts(opts, ref) do
+    # TODO: Use a pool of size > 1
+      opts
+      |> after_connect_hook(ref)
+      |> Keyword.put(:pool, DBConnection.Connection)
+      |> Keyword.put(:sync_connect, false)
+      |> Keyword.put(:idle, :passive)
+  end
+
+  defp after_connect_hook(opts, ref) do
+    Keyword.update(opts, :after_connect,
+      {__MODULE__, :after_connect, [self(), ref]}, &{__MODULE__, :after_connect, [self(), ref, &1]})
+  end
+
+  def after_connect(conn, pool, ref, fun \\ fn _ -> :ok end) do
+    res = apply_fun(fun, conn)
+    GenServer.cast(pool, {:connected, System.monotonic_time(:milliseconds), ref})
+    res
+  end
+
+  defp apply_fun(fun, conn) when is_function(fun, 1) do
+    fun.(conn)
+  end
+  defp apply_fun({mod, fun, args}, conn) do
+    apply(mod, fun, [conn | args])
+  end
+end
+    

--- a/lib/db_connection/connection_pool.ex
+++ b/lib/db_connection/connection_pool.ex
@@ -158,7 +158,7 @@ defmodule DBConnection.ConnectionPool do
             timeout(delay, time, queue, start_poll(time, sent, codel))
         {sent, _, _} ->
             {:noreply, {status, queue, start_poll(time, sent, codel)}}
-        :"$end_of_table" ->
+        _ ->
             {:noreply, {status, queue, start_poll(time, time, codel)}}
     end
   end
@@ -172,7 +172,7 @@ defmodule DBConnection.ConnectionPool do
             ping(holder, queue, start_idle(time, last_sent, codel))
         {sent, _} ->
             {:noreply, {status, queue, start_idle(time, sent, codel)}}
-        :"$end_of_table" ->
+        _ ->
             {:noreply, {status, queue, start_idle(time, time, codel)}}
     end
   end

--- a/lib/db_connection/connection_pool/pool.ex
+++ b/lib/db_connection/connection_pool/pool.ex
@@ -1,0 +1,17 @@
+defmodule DBConnection.ConnectionPool.Pool do
+  @moduledoc false
+
+  def start_link(owner, tag, mod, opts) do
+    size = Keyword.get(opts, :pool_size, 20)
+    children = for id <- 1..size, do: conn(owner, tag, id, mod, opts)
+    sup_opts = [strategy: :one_for_one] ++ Keyword.take(opts, [:max_restarts, :max_seconds])
+    Supervisor.start_link(children, sup_opts)
+  end
+
+  ## Helpers
+
+  defp conn(owner, tag, id, mod, opts) do
+    child_opts = [id: {mod, owner, id}] ++ Keyword.take(opts, [:shutdown])
+    DBConnection.Connection.child_spec(mod, opts, :connection_pool, {owner, tag}, child_opts)
+  end
+end

--- a/lib/db_connection/connection_pool/pool_supervisor.ex
+++ b/lib/db_connection/connection_pool/pool_supervisor.ex
@@ -1,0 +1,16 @@
+defmodule DBConnection.ConnectionPool.PoolSupervisor do
+  @moduledoc false
+
+  alias DBConnection.ConnectionPool.Pool
+  import Supervisor.Spec
+
+  def start_link() do
+    pool = supervisor(Pool, [], [restart: :temporary])
+    sup_opts = [strategy: :simple_one_for_one, name: __MODULE__]
+    Supervisor.start_link([pool], sup_opts)
+  end
+
+  def start_pool(tag, mod, opts) do
+    DBConnection.Watcher.watch(__MODULE__, [self(), tag, mod, opts])
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule DBConnection.Mixfile do
   use Mix.Project
 
-  @pools [:connection, :poolboy, :sojourn, :ownership]
+  @pools [:connection, :connection_pool, :poolboy, :sojourn, :ownership]
   @version "1.1.2"
 
   def project do


### PR DESCRIPTION
Adds a built in connection pool that will increase throughput by 3-7% for most single queries and load levels in Ecto. Other workloads may get 0%-10% improvements. 

The pool uses an ETS queue and some other ETS trickier to avoid tracking busy connections/clients. The later feature (if this was only pool style) would allow us to stop using the pdict so that we can ensure no data leaks for non-closure transactions.

We might be able to get better performance by removing either or both of these ETS use cases.

IO overload handling is better (and simpler) than Sojourn pool. In future we could improve the case where the database is down or other side of netsplit because we can know when there are no connections.

CPU overload handling is not as good as Sojourn pool but could be improved by limiting the queue size and dropping all new checkouts above that size.

There is no overflow. This is something we could do in future if we have a simple and good algorithm.

Idle ping handling is improved over other pools because pings will never synchronize and happen as rarely as possible.

Timeout handling is improved over other pools because an absolute deadline can be used (useful for multiple repo or multi service calls) and the queue time is included in the timeout if not absolute. Also queue timeouts are `DBConnection.ConnectionError` errors, like Sojourn pool, so easier to handle.

Processes hibernation occurs efficiently and does not affect performance. It could be more efficient if hibernate on backoff.

Overhead for `pool_size: 1` is insignificant compared to `DBConnection.Connection` so could replace it.