### PR TITLE
Use optional_callbacks instead of relying on default implementations

### DIFF
--- a/integration_test/cases/prepare_stream_test.exs
+++ b/integration_test/cases/prepare_stream_test.exs
@@ -13,8 +13,8 @@ defmodule PrepareStreamTest do
       {:ok, :began, :new_state},
       {:ok, %Q{}, :newer_state},
       {:ok, %C{}, :newest_state},
-      {:ok, %R{}, :state2},
-      {:deallocate, %R{}, :new_state2},
+      {:cont, %R{}, :state2},
+      {:halt, %R{}, :new_state2},
       {:ok, :deallocated, :newer_state2},
       {:ok, :committed, :newest_state2}
       ]
@@ -34,8 +34,8 @@ defmodule PrepareStreamTest do
       handle_begin: [_, :state],
       handle_prepare: [%Q{}, _, :new_state],
       handle_declare: [%Q{}, [:param], _, :newer_state],
-      handle_first: [%Q{}, %C{}, _, :newest_state],
-      handle_next: [%Q{}, %C{}, _, :state2],
+      handle_fetch: [%Q{}, %C{}, _, :newest_state],
+      handle_fetch: [%Q{}, %C{}, _, :state2],
       handle_deallocate: [%Q{}, %C{}, _, :new_state2],
       handle_commit: [_, :newer_state2]
       ] = A.record(agent)
@@ -47,7 +47,7 @@ defmodule PrepareStreamTest do
       {:ok, :began, :new_state},
       {:ok, %Q{state: :prepared}, :newer_state},
       {:ok, %C{}, :newest_state},
-      {:deallocate, %R{}, :state2},
+      {:halt, %R{}, :state2},
       {:ok, :deallocated, :new_state2},
       {:ok, :committed, :newer_state2}
       ]
@@ -71,7 +71,7 @@ defmodule PrepareStreamTest do
       handle_begin: [_, :state],
       handle_prepare: [%Q{state: :parsed}, _, :new_state],
       handle_declare: [%Q{state: :described}, :encoded, _, :newer_state],
-      handle_first: [%Q{state: :described}, %C{}, _, :newest_state],
+      handle_fetch: [%Q{state: :described}, %C{}, _, :newest_state],
       handle_deallocate: [%Q{}, %C{}, _, :state2],
       handle_commit: [_, :new_state2]
       ] = A.record(agent)
@@ -83,7 +83,7 @@ defmodule PrepareStreamTest do
       {:ok, :began, :new_state},
       {:ok, %Q{}, :newer_state},
       {:ok, %C{}, :newest_state},
-      {:ok, %R{}, :state2},
+      {:halt, %R{}, :state2},
       {:ok, :deallocated, :new_state2},
       {:ok, :committed, :newest_state2}
       ]
@@ -125,7 +125,7 @@ defmodule PrepareStreamTest do
       handle_begin: [_, :state],
       handle_prepare: [%Q{}, _, :new_state],
       handle_declare: [%Q{}, [:param], _, :newer_state],
-      handle_first: [%Q{}, %C{}, _, :newest_state],
+      handle_fetch: [%Q{}, %C{}, _, :newest_state],
       handle_deallocate: [%Q{}, %C{}, _, :state2],
       handle_commit: [_, :new_state2]
       ] = A.record(agent)

--- a/integration_test/cases/stream_test.exs
+++ b/integration_test/cases/stream_test.exs
@@ -13,8 +13,8 @@ defmodule StreamTest do
       {:ok, :state},
       {:ok, :began, :new_state},
       {:ok, %C{}, :newer_state},
-      {:ok, %R{}, :newest_state},
-      {:deallocate, %R{}, :state2},
+      {:cont, %R{}, :newest_state},
+      {:halt, %R{}, :state2},
       {:ok, :deallocated, :new_state2},
       {:ok, :commited, :newer_state2}
       ]
@@ -33,8 +33,8 @@ defmodule StreamTest do
       connect: [_],
       handle_begin: [_, :state],
       handle_declare: [%Q{}, [:param], _, :new_state],
-      handle_first: [%Q{}, %C{}, _, :newer_state],
-      handle_next: [%Q{}, %C{}, _, :newest_state],
+      handle_fetch: [%Q{}, %C{}, _, :newer_state],
+      handle_fetch: [%Q{}, %C{}, _, :newest_state],
       handle_deallocate: [%Q{}, %C{}, _, :state2],
       handle_commit: [_, :new_state2]
       ] = A.record(agent)
@@ -45,7 +45,7 @@ defmodule StreamTest do
       {:ok, :state},
       {:ok, :began, :new_state},
       {:ok, %C{}, :newer_state},
-      {:deallocate, %R{}, :newest_state},
+      {:halt, %R{}, :newest_state},
       {:ok, :deallocated, :state2},
       {:ok, :committed, :new_state2}
       ]
@@ -66,7 +66,7 @@ defmodule StreamTest do
       connect: [_],
       handle_begin: [_, :state],
       handle_declare: [_, :encoded, _, :new_state],
-      handle_first: [%Q{}, %C{}, _, :newer_state],
+      handle_fetch: [%Q{}, %C{}, _, :newer_state],
       handle_deallocate: [%Q{}, %C{}, _, :newest_state],
       handle_commit: [_, :state2]
       ] = A.record(agent)
@@ -77,7 +77,7 @@ defmodule StreamTest do
       {:ok, :state},
       {:ok, :began, :new_state},
       {:ok, %Q{state: :replaced}, %C{}, :newer_state},
-      {:deallocate, %R{}, :newest_state},
+      {:halt, %R{}, :newest_state},
       {:ok, :deallocated, :state2},
       {:ok, :committed, :new_state2}
       ]
@@ -98,7 +98,7 @@ defmodule StreamTest do
       connect: [_],
       handle_begin: [_, :state],
       handle_declare: [_, [:param], _, :new_state],
-      handle_first: [%Q{state: :replaced}, %C{}, _, :newer_state],
+      handle_fetch: [%Q{state: :replaced}, %C{}, _, :newer_state],
       handle_deallocate: [%Q{state: :replaced}, %C{}, _, :newest_state],
       handle_commit: [_, :state2]
       ] = A.record(agent)
@@ -109,7 +109,7 @@ defmodule StreamTest do
       {:ok, :state},
       {:ok, :began, :new_state},
       {:ok, %C{}, :newer_state},
-      {:ok, %R{}, :newest_state},
+      {:cont, %R{}, :newest_state},
       {:ok, :result, :state2},
       {:ok, :committed, :new_state2}
       ]
@@ -150,7 +150,7 @@ defmodule StreamTest do
       connect: [_],
       handle_begin: [_, :state],
       handle_declare: [%Q{}, [:param], _, :new_state],
-      handle_first: [%Q{}, %C{}, _, :newer_state],
+      handle_fetch: [%Q{}, %C{}, _, :newer_state],
       handle_deallocate: [%Q{}, %C{}, _, :newest_state],
       handle_commit: [_, :state2]
       ] = A.record(agent)
@@ -273,7 +273,7 @@ defmodule StreamTest do
       connect: [_],
       handle_begin: [_, :state],
       handle_declare: [%Q{}, [:param], _, :new_state],
-      handle_first: [%Q{}, %C{}, _, :newer_state],
+      handle_fetch: [%Q{}, %C{}, _, :newer_state],
       disconnect: [^err, :newest_state],
       connect: [_]
       ] = A.record(agent)
@@ -284,7 +284,7 @@ defmodule StreamTest do
       {:ok, :state},
       {:ok, :began, :new_state},
       {:ok, %C{}, :newer_state},
-      {:ok, %R{}, :newest_state},
+      {:cont, %R{}, :newest_state},
       {:ok, :deallocated, :state2},
       {:ok, :rolledback, :new_state2}
       ]
@@ -306,7 +306,7 @@ defmodule StreamTest do
       connect: [_],
       handle_begin: [_, :state],
       handle_declare: [%Q{}, [:param], _, :new_state],
-      handle_first: [%Q{}, %C{}, _, :newer_state],
+      handle_fetch: [%Q{}, %C{}, _, :newer_state],
       handle_deallocate: [%Q{}, %C{}, _, :newest_state],
       handle_rollback: [_, :state2]
       ] = A.record(agent)
@@ -318,7 +318,7 @@ defmodule StreamTest do
       {:ok, :state},
       {:ok, :began, :new_state},
       {:ok, %C{}, :newer_state},
-      {:ok, %R{}, :newest_state},
+      {:cont, %R{}, :newest_state},
       {:disconnect, err, :state2},
       :ok,
       fn(opts) ->
@@ -354,7 +354,7 @@ defmodule StreamTest do
       connect: [_],
       handle_begin: [_, :state],
       handle_declare: [%Q{}, [:param], _, :new_state],
-      handle_first: [%Q{}, %C{}, _, :newer_state],
+      handle_fetch: [%Q{}, %C{}, _, :newer_state],
       handle_deallocate: [%Q{}, %C{}, _, :newest_state],
       disconnect: [^err, :state2],
       connect: [_]
@@ -444,7 +444,7 @@ defmodule StreamTest do
       {:ok, :state},
       {:ok, :began, :new_state},
       {:ok, %C{}, :newer_state},
-      {:deallocate, %R{}, :newest_state},
+      {:halt, %R{}, :newest_state},
       {:ok, :deallocated, :state2},
       {:ok, :commited, :new_state2}
       ]
@@ -467,7 +467,7 @@ defmodule StreamTest do
       connect: [_],
       handle_begin: [_, :state],
       handle_declare: [%Q{}, [:param], _, :new_state],
-      handle_first: [%Q{}, %C{}, _, :newer_state],
+      handle_fetch: [%Q{}, %C{}, _, :newer_state],
       handle_deallocate: [%Q{}, %C{}, _, :newest_state],
       handle_commit: [_, :state2]
       ] = A.record(agent)
@@ -511,7 +511,7 @@ defmodule StreamTest do
       {:connect, _},
       {:handle_begin, [_, :state]},
       {:handle_declare, [%Q{}, [:param], _, :new_state]},
-      {:handle_first, [%Q{}, %C{}, _, :newer_state]} | _] = A.record(agent)
+      {:handle_fetch, [%Q{}, %C{}, _, :newer_state]} | _] = A.record(agent)
   end
 
   test "stream deallocate raise raises and stops connection" do
@@ -523,7 +523,7 @@ defmodule StreamTest do
       end,
       {:ok, :began, :new_state},
       {:ok, %C{}, :newer_state},
-      {:ok, %R{}, :newest_state},
+      {:cont, %R{}, :newest_state},
       fn(_, _, _, _) ->
         raise "oops"
       end,
@@ -553,7 +553,7 @@ defmodule StreamTest do
       {:connect, _},
       {:handle_begin, [_, :state]},
       {:handle_declare, [%Q{}, [:param], _, :new_state]},
-      {:handle_first, [%Q{}, %C{}, _, :newer_state]},
+      {:handle_fetch, [%Q{}, %C{}, _, :newer_state]},
       {:handle_deallocate, [%Q{}, %C{}, _, :newest_state]} | _] = A.record(agent)
   end
 end

--- a/lib/db_connection/connection.ex
+++ b/lib/db_connection/connection.ex
@@ -258,16 +258,12 @@ defmodule DBConnection.Connection do
 
   @doc false
   def handle_cast({:ping, ref, state}, %{client: {ref, :pool}, mod: mod} = s) do
-    if function_exported?(mod, :ping, 1) do
-      case apply(mod, :ping, [state]) do
-        {:ok, state} ->
-          pool_update(state, s)
+    case apply(mod, :ping, [state]) do
+      {:ok, state} ->
+        pool_update(state, s)
 
-        {:disconnect, err, state} ->
-          {:disconnect, {:log, err}, %{s | state: state}}
-      end
-    else
-      {:noreply, s, :hibernate}
+      {:disconnect, err, state} ->
+        {:disconnect, {:log, err}, %{s | state: state}}
     end
   end
 

--- a/test/db_connection_test.exs
+++ b/test/db_connection_test.exs
@@ -4,51 +4,6 @@ defmodule DBConnectionTest do
   alias TestConnection, as: C
   alias TestAgent, as: A
 
-  test "__using__ defaults" do
-    defmodule Sample do
-      use DBConnection
-    end
-
-    try do
-      assert_raise RuntimeError, "connect/1 not implemented",
-        fn() -> Sample.connect([]) end
-
-      assert_raise RuntimeError, "disconnect/2 not implemented",
-        fn() -> Sample.disconnect(RuntimeError.exception("oops"), []) end
-
-      assert_raise RuntimeError, "checkout/1 not implemented",
-        fn() -> Sample.checkout(:state) end
-
-      assert_raise RuntimeError, "checkin/1 not implemented",
-        fn() -> Sample.checkin(:state) end
-
-      assert Sample.ping(:state) == {:ok, :state}
-
-      assert_raise RuntimeError, "handle_begin/2 not implemented",
-        fn() -> Sample.handle_begin([], :state) end
-
-      assert_raise RuntimeError, "handle_commit/2 not implemented",
-        fn() -> Sample.handle_commit([], :state) end
-
-      assert_raise RuntimeError, "handle_rollback/2 not implemented",
-        fn() -> Sample.handle_rollback([], :state) end
-
-      assert_raise RuntimeError, "handle_prepare/3 not implemented",
-        fn() -> Sample.handle_prepare(:query, [], :state) end
-
-      assert_raise RuntimeError, "handle_execute/4 not implemented",
-        fn() -> Sample.handle_execute(:query, [], [], :state) end
-
-      assert_raise RuntimeError, "handle_close/3 not implemented",
-        fn() -> Sample.handle_close(:query, [], :state) end
-
-      assert Sample.handle_info(:msg, :state) == {:ok, :state}
-    after
-      :code.purge(Sample)
-      :code.delete(Sample)
-    end
-  end
-
   test "start_link workflow with unregistered name" do
     stack = [{:ok, :state}]
     {:ok, agent} = A.start_link(stack)

--- a/test/test_support.exs
+++ b/test/test_support.exs
@@ -167,14 +167,6 @@ defmodule TestConnection do
     TestAgent.eval(:handle_fetch, [query, cursor, opts, state])
   end
 
-  def handle_first(query, cursor, opts, state) do
-    TestAgent.eval(:handle_first, [query, cursor, opts, state])
-  end
-
-  def handle_next(query, cursor, opts, state) do
-    TestAgent.eval(:handle_next, [query, cursor, opts, state])
-  end
-
   def handle_deallocate(query, cursor, opts, state) do
     TestAgent.eval(:handle_deallocate, [query, cursor, opts, state])
   end
@@ -183,7 +175,6 @@ defmodule TestConnection do
     TestAgent.eval(:handle_info, [msg, state])
   end
 end
-
 
 defmodule TestQuery do
   defstruct [:state]
@@ -224,7 +215,6 @@ defimpl DBConnection.Query, for: TestQuery do
 end
 
 defmodule TestAgent do
-
   def start_link(stack) do
     {:ok, agent} = ok = Agent.start_link(fn() -> {stack, []} end)
     _ = Process.put(:agent, agent)


### PR DESCRIPTION
This commit also moves the handling of replies to each callback
instead of a main `handle` function as otherwise we would need
to push `function_exported?/3` concerns into it.