### PR TITLE
Update docs

### DIFF
--- a/lib/db_connection.ex
+++ b/lib/db_connection.ex
@@ -206,7 +206,7 @@ defmodule DBConnection do
   """
   @callback handle_rollback(opts :: Keyword.t, state :: any) ::
     {:ok, result, new_state :: any} |
-    {:idle, new_state :: any} |
+    {status, new_state :: any} |
     {:disconnect, Exception.t, new_state :: any}
 
   @doc """

--- a/lib/db_connection.ex
+++ b/lib/db_connection.ex
@@ -219,7 +219,7 @@ defmodule DBConnection do
   `:error`.
   """
   @callback handle_status(opts :: Keyword.t, state :: any) ::
-    {:idle | :transaction | :error, new_state :: any} |
+    {status, new_state :: any} |
     {:disconnect, Exception.t, new_state :: any}
 
   @doc """

--- a/lib/db_connection.ex
+++ b/lib/db_connection.ex
@@ -240,7 +240,6 @@ defmodule DBConnection do
 
   @doc """
   Execute a query prepared by `c:handle_prepare/3`. Return
-  `{:ok, result, state}` to return the result `result` and continue,
   `{:ok, query, result, state}` to return altered query `query` and result
   `result` and continue, `{:error, exception, state}` to return an error and
   continue or `{:disconnect, exception, state}` to return an error and

--- a/lib/db_connection.ex
+++ b/lib/db_connection.ex
@@ -266,7 +266,6 @@ defmodule DBConnection do
 
   @doc """
   Declare a cursor using a query prepared by `c:handle_prepare/3`. Return
-  `{:ok, cursor, state}` to start a cursor for a stream and continue,
   `{:ok, query, cursor, state}` to return altered query `query` and cursor
   `cursor` for a stream and continue, `{:error, exception, state}` to return an
   error and continue or `{:disconnect, exception, state}` to return an error


### PR DESCRIPTION
- handle_declare no longer can return {:ok, cursor, state}
- handle_prepare no longer can return {:ok, result, state}
- handle_rollback can return any status
- Re-use status type in handle_status