### PR TITLE
Add start_option/0 and option/0 types

### DIFF
--- a/lib/db_connection.ex
+++ b/lib/db_connection.ex
@@ -103,6 +103,28 @@ defmodule DBConnection do
   @type cursor :: any
   @type status :: :idle | :transaction | :error
 
+  @type start_option ::
+          {:after_connect, (t -> any) | {module, atom, [any]} | nil}
+          | {:after_connect_timeout, timeout}
+          | {:backoff_max, non_neg_integer}
+          | {:backoff_min, non_neg_integer}
+          | {:backoff_type, :stop | :exp | :rand | :rand_exp}
+          | {:configure, (keyword -> keyword) | {module, atom, [any]} | nil}
+          | {:idle_interval, non_neg_integer}
+          | {:max_restarts, non_neg_integer}
+          | {:max_seconds, pos_integer}
+          | {:name, GenServer.name()}
+          | {:pool, module}
+          | {:pool_size, pos_integer}
+          | {:queue_interval, non_neg_integer}
+          | {:queue_target, non_neg_integer}
+          | {:show_sensitive_data_on_connection_error, boolean}
+
+  @type option ::
+          {:log, (DBConnection.LogEntry.t -> any) | {module, atom, [any]} | nil}
+          | {:queue, boolean}
+          | {:timeout, timeout}
+
   @doc """
   Connect to the database. Return `{:ok, state}` on success or
   `{:error, exception}` on failure.

--- a/lib/db_connection.ex
+++ b/lib/db_connection.ex
@@ -124,7 +124,7 @@ defmodule DBConnection do
           {:log, (DBConnection.LogEntry.t -> any) | {module, atom, [any]} | nil}
           | {:queue, boolean}
           | {:timeout, timeout}
-          | {:deadline, integer}
+          | {:deadline, integer | nil}
 
   @doc """
   Connect to the database. Return `{:ok, state}` on success or
@@ -446,9 +446,10 @@ defmodule DBConnection do
     `start_link/2` docs
     * `:timeout` - The maximum time that the caller is allowed to perform
     this operation (default: `15_000`)
-    * `:deadline` - If set, specifies absolute monotonic time in milliseconds
-    by which caller must perform operation. See `System` module documentation
-    for more information on monotonic time
+    * `:deadline` - If set, overrides `:timeout` option and specifies absolute
+    monotonic time in milliseconds by which caller must perform operation.
+    See `System` module documentation for more information on monotonic time
+    (default: `nil`)
     * `:log` - A function to log information about a call, either
     a 1-arity fun, `{module, function, args}` with `t:DBConnection.LogEntry.t/0`
     prepended to `args` or `nil`. See `DBConnection.LogEntry` (default: `nil`)
@@ -508,6 +509,10 @@ defmodule DBConnection do
     `start_link/2` docs
     * `:timeout` - The maximum time that the caller is allowed to perform
     this operation (default: `15_000`)
+    * `:deadline` - If set, overrides `:timeout` option and specifies absolute
+    monotonic time in milliseconds by which caller must perform operation.
+    See `System` module documentation for more information on monotonic time
+    (default: `nil`)
     * `:log` - A function to log information about a call, either
     a 1-arity fun, `{module, function, args}` with `t:DBConnection.LogEntry.t/0`
     prepended to `args` or `nil`. See `DBConnection.LogEntry` (default: `nil`)
@@ -566,6 +571,10 @@ defmodule DBConnection do
     `start_link/2` docs
     * `:timeout` - The maximum time that the caller is allowed to perform
     this operation (default: `15_000`)
+    * `:deadline` - If set, overrides `:timeout` option and specifies absolute
+    monotonic time in milliseconds by which caller must perform operation.
+    See `System` module documentation for more information on monotonic time
+    (default: `nil`)
     * `:log` - A function to log information about a call, either
     a 1-arity fun, `{module, function, args}` with `t:DBConnection.LogEntry.t/0`
     prepended to `args` or `nil`. See `DBConnection.LogEntry` (default: `nil`)
@@ -624,6 +633,10 @@ defmodule DBConnection do
     `start_link/2` docs
     * `:timeout` - The maximum time that the caller is allowed to perform
     this operation (default: `15_000`)
+    * `:deadline` - If set, overrides `:timeout` option and specifies absolute
+    monotonic time in milliseconds by which caller must perform operation.
+    See `System` module documentation for more information on monotonic time
+    (default: `nil`)
     * `:log` - A function to log information about a call, either
     a 1-arity fun, `{module, function, args}` with `t:DBConnection.LogEntry.t/0`
     prepended to `args` or `nil`. See `DBConnection.LogEntry` (default: `nil`)
@@ -676,6 +689,10 @@ defmodule DBConnection do
     `start_link/2` docs
     * `:timeout` - The maximum time that the caller is allowed to perform
     this operation (default: `15_000`)
+    * `:deadline` - If set, overrides `:timeout` option and specifies absolute
+    monotonic time in milliseconds by which caller must perform operation.
+    See `System` module documentation for more information on monotonic time
+    (default: `nil`)
 
   The pool may support other options.
 
@@ -758,6 +775,10 @@ defmodule DBConnection do
     `start_link/2` docs
     * `:timeout` - The maximum time that the caller is allowed to perform
     this operation (default: `15_000`)
+    * `:deadline` - If set, overrides `:timeout` option and specifies absolute
+    monotonic time in milliseconds by which caller must perform operation.
+    See `System` module documentation for more information on monotonic time
+    (default: `nil`)
     * `:log` - A function to log information about begin, commit and rollback
     calls made as part of the transaction, either a 1-arity fun,
     `{module, function, args}` with `t:DBConnection.LogEntry.t/0` prepended to
@@ -897,6 +918,10 @@ defmodule DBConnection do
     `start_link/2` docs
     * `:timeout` - The maximum time that the caller is allowed to perform
     this operation (default: `15_000`)
+    * `:deadline` - If set, overrides `:timeout` option and specifies absolute
+    monotonic time in milliseconds by which caller must perform operation.
+    See `System` module documentation for more information on monotonic time
+    (default: `nil`)
     * `:log` - A function to log information about a call, either
     a 1-arity fun, `{module, function, args}` with `t:DBConnection.LogEntry.t/0`
     prepended to `args` or `nil`. See `DBConnection.LogEntry` (default: `nil`)
@@ -931,6 +956,10 @@ defmodule DBConnection do
     `start_link/2` docs
     * `:timeout` - The maximum time that the caller is allowed to perform
     this operation (default: `15_000`)
+    * `:deadline` - If set, overrides `:timeout` option and specifies absolute
+    monotonic time in milliseconds by which caller must perform operation.
+    See `System` module documentation for more information on monotonic time
+    (default: `nil`)
     * `:log` - A function to log information about a call, either
     a 1-arity fun, `{module, function, args}` with `t:DBConnection.LogEntry.t/0`
     prepended to `args` or `nil`. See `DBConnection.LogEntry` (default: `nil`)

--- a/lib/db_connection.ex
+++ b/lib/db_connection.ex
@@ -124,6 +124,7 @@ defmodule DBConnection do
           {:log, (DBConnection.LogEntry.t -> any) | {module, atom, [any]} | nil}
           | {:queue, boolean}
           | {:timeout, timeout}
+          | {:deadline, integer}
 
   @doc """
   Connect to the database. Return `{:ok, state}` on success or
@@ -445,6 +446,9 @@ defmodule DBConnection do
     `start_link/2` docs
     * `:timeout` - The maximum time that the caller is allowed to perform
     this operation (default: `15_000`)
+    * `:deadline` - If set, specifies absolute monotonic time in milliseconds
+    by which caller must perform operation. See `System` module documentation
+    for more information on monotonic time
     * `:log` - A function to log information about a call, either
     a 1-arity fun, `{module, function, args}` with `t:DBConnection.LogEntry.t/0`
     prepended to `args` or `nil`. See `DBConnection.LogEntry` (default: `nil`)


### PR DESCRIPTION
See https://github.com/elixir-ecto/myxql/pull/41/files for how it can be used. When this is merged, I'll perform similar changes in Postgrex.

Latest versions on Hex are db_connection 2.0.5 and postgrex 0.14.1. Say we release these types on 2.0.6 and 0.14.2, respectively. If users update to Postgrex 0.14.2 but keeps db_connection < 2.0.6, they will get a Dialyzer error:

    Unknown type: DBConnection.start_option/0

We could bump Postgrex's dependency requirement but that seems too much? Perhaps having this comment here should be enough to unblock folks if they run into it.