### PR TITLE
Fix race condition where we checkin a connection after timeout

### DIFF
--- a/integration_test/cases/queue_test.exs
+++ b/integration_test/cases/queue_test.exs
@@ -145,4 +145,20 @@ defmodule QueueTest do
 
     assert P.run(pool, fn(_) -> :hi end) == :hi
   end
+
+  test "queue handles holder that has been deleted" do
+    stack = [{:ok, :state}, {:idle, :state}, {:idle, :state}, :ok, {:ok, :new_state}, {:idle, :new_state}, {:idle, :new_state}]
+    {:ok, agent} = A.start_link(stack)
+
+    opts = [agent: agent, parent: self()]
+    {:ok, pool} = P.start_link(opts)
+
+    P.run(pool, fn(_) ->
+      :sys.suspend(pool)
+      :timer.sleep(1000)
+      :sys.resume(pool)
+    end, [timeout: 100])
+
+    P.run(pool, fn(_) -> :ok end)
+  end
 end

--- a/lib/db_connection/connection_pool.ex
+++ b/lib/db_connection/connection_pool.ex
@@ -71,7 +71,13 @@ defmodule DBConnection.ConnectionPool do
   def handle_info({:"ETS-TRANSFER", holder, _, {msg, queue, extra}}, {_, queue, _} = data) do
     case msg do
       :checkin ->
-        handle_checkin(holder, extra, data)
+        owner = self()
+        case :ets.info(holder, :owner) do
+          ^owner ->
+            handle_checkin(holder, extra, data)
+          :undefined ->
+            {:noreply, data}
+        end
       :disconnect ->
         Holder.handle_disconnect(holder, extra)
         {:noreply, data}


### PR DESCRIPTION
It was possible for a deadline timeout to arrive at the connection pool and for the deadline to be current in the holder but the client to checkin the connection holder before the pool deleted the holder for disconnect. This leads to an `ETS-TRANSFER` message with the deleted holder being handled by the pool and added to the queue. Therefore we check holders exist before checking in, and crash if we get in a inconsistent due to a future bug.