### PR TITLE
Ping all stale connections on idle interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v2.2.0
+
+* Enhancements
+  * Add `crash_reson` to relevant Logger error reports
+  * Ping all stale connections on idle interval. One possible downside of this approach is that we may shut down all connections at once and if there is a request around this time, the response time will be higher. However, this is likely better than the current approach, where we ping only the first one, which means we can have a pool of stale connections. The current behaviour is the same as in v1.0
+
 ## v2.1.1 (2019-07-17)
 
 * Enhancements

--- a/integration_test/cases/idle_test.exs
+++ b/integration_test/cases/idle_test.exs
@@ -7,27 +7,30 @@ defmodule TestIdle do
   @tag :idle_interval
   test "ping after idle interval" do
     parent = self()
+
     stack = [
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], {:hi, self()})
         {:ok, :state}
       end,
-      fn(_) ->
+      fn _ ->
         send(parent, {:pong, self()})
         :timer.sleep(10)
         {:ok, :state}
       end,
-      fn(_) ->
+      fn _ ->
         send(parent, {:pong, self()})
         assert_receive {:continue, ^parent}
         {:ok, :state}
       end,
       {:idle, :state},
       {:idle, :state},
-      fn(_) ->
+      fn _ ->
         send(parent, {:pong, self()})
         :timer.sleep(:infinity)
-      end]
+      end
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self(), idle_interval: 50]
@@ -36,15 +39,93 @@ defmodule TestIdle do
     assert_receive {:pong, ^conn}
     assert_receive {:pong, ^conn}
     send(conn, {:continue, self()})
-    P.run(pool, fn(_) -> :ok end)
+    P.run(pool, fn _ -> :ok end)
     assert_receive {:pong, ^conn}
 
     assert [
-      connect: [_],
-      ping: [:state],
-      ping: [:state],
-      handle_status: _,
-      handle_status: _,
-      ping: [:state]] = A.record(agent)
+             connect: [_],
+             ping: [:state],
+             ping: [:state],
+             handle_status: _,
+             handle_status: _,
+             ping: [:state]
+           ] = A.record(agent)
+  end
+
+  @tag :idle_interval
+  test "ping multiple after idle interval" do
+    parent = self()
+
+    stack = [
+      fn opts ->
+        send(opts[:parent], {:hi, self()})
+        {:ok, :state}
+      end,
+      fn _ ->
+        send(parent, {:pong, self()})
+        :timer.sleep(10)
+        {:ok, :state}
+      end,
+      fn _ ->
+        send(parent, {:pong, self()})
+        assert_receive {:continue, ^parent}
+        {:ok, :state}
+      end,
+      {:idle, :state},
+      {:idle, :state},
+      fn _ ->
+        send(parent, {:pong, self()})
+        :timer.sleep(:infinity)
+      end
+    ]
+
+    {:ok, agent1} = A.start_link(stack)
+    {:ok, agent2} = A.start_link(stack)
+
+    opts = [agent: [agent1, agent2], parent: self(), idle_interval: 50, pool_size: 2]
+    {:ok, pool} = P.start_link(opts)
+    assert_receive {:hi, conn1}
+    assert_receive {:hi, conn2}
+    assert_receive {:pong, ^conn1}
+    assert_receive {:pong, ^conn2}
+    assert_receive {:pong, ^conn1}
+    assert_receive {:pong, ^conn2}
+    send(conn1, {:continue, self()})
+    send(conn2, {:continue, self()})
+
+    task1 =
+      Task.async(fn ->
+        Process.put(:agent, agent1)
+        P.run(pool, fn _ -> assert_receive :done end)
+      end)
+
+    task2 =
+      Task.async(fn ->
+        Process.put(:agent, agent2)
+        P.run(pool, fn _ -> assert_receive :done end)
+      end)
+
+    send(task1.pid, :done)
+    send(task2.pid, :done)
+    assert_receive {:pong, ^conn1}
+    assert_receive {:pong, ^conn2}
+
+    assert [
+             connect: [_],
+             ping: [:state],
+             ping: [:state],
+             handle_status: _,
+             handle_status: _,
+             ping: [:state]
+           ] = A.record(agent1)
+
+    assert [
+             connect: [_],
+             ping: [:state],
+             ping: [:state],
+             handle_status: _,
+             handle_status: _,
+             ping: [:state]
+           ] = A.record(agent2)
   end
 end

--- a/lib/db_connection.ex
+++ b/lib/db_connection.ex
@@ -60,9 +60,9 @@ defmodule DBConnection do
   timeout and its request will be cancelled. This prevents requests
   building up when the database can not keep up.
 
-  If no requests are received for a period of time the connection will
-  trigger an idle timeout and the database can be pinged to keep the
-  connection alive.
+  If no requests are received for an idle interval, the pool will
+  ping all stale connections which can then ping the database to keep
+  the connection alive.
 
   Should the connection be lost, attempts will be made to reconnect with
   (configurable) exponential random backoff to reconnect. All state is

--- a/lib/db_connection/connection_pool/pool.ex
+++ b/lib/db_connection/connection_pool/pool.ex
@@ -24,6 +24,6 @@ defmodule DBConnection.ConnectionPool.Pool do
 
   defp conn(owner, tag, id, mod, opts) do
     child_opts = [id: {mod, owner, id}] ++ Keyword.take(opts, [:shutdown])
-    DBConnection.Connection.child_spec(mod, opts, owner, tag, child_opts)
+    DBConnection.Connection.child_spec(mod, [pool_index: id] ++ opts, owner, tag, child_opts)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule DBConnection.Mixfile do
   use Mix.Project
 
   @pools [:connection_pool, :ownership]
-  @version "2.1.1"
+  @version "2.2.0"
 
   def project do
     [app: :db_connection,

--- a/test/db_connection_test.exs
+++ b/test/db_connection_test.exs
@@ -15,7 +15,7 @@ defmodule DBConnectionTest do
     assert conn in links
 
     _ = :sys.get_state(conn)
-    assert A.record(agent) == [{:connect, [opts]}]
+    assert A.record(agent) == [{:connect, [[pool_index: 1] ++ opts]}]
   end
 
   test "start_link workflow with registered name" do
@@ -28,6 +28,6 @@ defmodule DBConnectionTest do
     assert Process.info(conn, :registered_name) == {:registered_name, :conn}
 
     _ = :sys.get_state(conn)
-    assert A.record(agent) == [{:connect, [opts]}]
+    assert A.record(agent) == [{:connect, [[pool_index: 1] ++ opts]}]
   end
 end

--- a/test/test_support.exs
+++ b/test/test_support.exs
@@ -156,7 +156,14 @@ defmodule TestConnection do
   end
 
   defp put_agent_from_opts(opts) do
-    Process.get(:agent) || Process.put(:agent, Keyword.fetch!(opts, :agent))
+    Process.get(:agent) || Process.put(:agent, agent_from_opts(opts))
+  end
+
+  defp agent_from_opts(opts) do
+    case opts[:agent] do
+      [_ | _] = agent -> Enum.fetch!(agent, Keyword.fetch!(opts, :pool_index) - 1)
+      agent -> agent
+    end
   end
 end
 


### PR DESCRIPTION
One possible downside of this approach is that
we may shut down all connections at once and if
there is a request around this time, the response
time will be higher. However, this is likely better
than the current approach, where we ping only the
first one, which means we can have a pool of stale
connections. Ideally we would introduce some sort
of jitter, to ensure we don't disconnect all of
them immediately, but this can be in the future.
The current behaviour is the same as in v1.0.