### PR TITLE
DBConnection.Watcher should handle unknown messages

### DIFF
--- a/lib/db_connection/watcher.ex
+++ b/lib/db_connection/watcher.ex
@@ -48,6 +48,10 @@ defmodule DBConnection.Watcher do
   def handle_info({:EXIT, _, _}, state) do
     {:noreply, state}
   end
+  
+  def handle_info(_, state) do
+    {:noreply, state}
+  end
 
   def terminate(_, {_, started_refs}) do
     for {_, {caller_pid, _}} <- started_refs do


### PR DESCRIPTION
This is a good practice because anything can send our Watcher process a message and crash it.
From my own experimentation, the process isn't starting back up, either.

Now, I should say that I _do_ have a process that sends messages to random processes,
as part of a chaos engineering effort on my team, so it's up to y'all if this is a practical concern or not.
From what I understand, though, implementing a catch-all `handle_info` clause is a best practice.