### PR TITLE
Replace deprecated stacktraces and bump requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - elixir: 1.6.6
-            otp: 19.3.6.13
           - elixir: 1.7.4
             otp: 19.3.6.13
           - elixir: 1.8.2

--- a/lib/db_connection.ex
+++ b/lib/db_connection.ex
@@ -717,9 +717,8 @@ defmodule DBConnection do
           {result, run(conn, &run_status/3, nil, opts)}
         catch
           kind, error ->
-            stacktrace = __STACKTRACE__
             checkin(conn)
-            :erlang.raise(kind, error, stacktrace)
+            :erlang.raise(kind, error, __STACKTRACE__)
         else
           {result, {:error, _, _}} ->
             checkin(conn)

--- a/lib/db_connection.ex
+++ b/lib/db_connection.ex
@@ -717,7 +717,7 @@ defmodule DBConnection do
           {result, run(conn, &run_status/3, nil, opts)}
         catch
           kind, error ->
-            stacktrace = System.stacktrace()
+            stacktrace = __STACKTRACE__
             checkin(conn)
             :erlang.raise(kind, error, stacktrace)
         else
@@ -807,7 +807,7 @@ defmodule DBConnection do
         fail(conn)
         {:error, reason}
       kind, reason ->
-        stack = System.stacktrace()
+        stack = __STACKTRACE__
         fail(conn)
         :erlang.raise(kind, reason, stack)
     else
@@ -1029,7 +1029,7 @@ defmodule DBConnection do
       holder.checkout(pool, opts)
     catch
       kind, reason ->
-        stack = System.stacktrace()
+        stack = __STACKTRACE__
         {kind, reason, stack, past_event(meter, :checkout, checkout)}
     else
       {:ok, pool_ref, _conn_mod, checkin, _conn_state} ->
@@ -1111,7 +1111,7 @@ defmodule DBConnection do
       raise DBConnection.ConnectionError, "bad return value: #{inspect other}"
     catch
       :error, reason ->
-        stack = System.stacktrace()
+        stack = __STACKTRACE__
         stop(conn, :error, reason, stack)
         {:error, reason, stack, meter}
     end
@@ -1122,7 +1122,7 @@ defmodule DBConnection do
       DBConnection.Query.parse(query, opts)
     catch
       kind, reason ->
-        stack = System.stacktrace()
+        stack = __STACKTRACE__
         {kind, reason, stack, meter}
     else
       query ->
@@ -1135,7 +1135,7 @@ defmodule DBConnection do
       DBConnection.Query.describe(query, opts)
     catch
       kind, reason ->
-        stack = System.stacktrace()
+        stack = __STACKTRACE__
         raised_close(conn, query, meter, opts, kind, reason, stack)
     else
       query ->
@@ -1148,7 +1148,7 @@ defmodule DBConnection do
       DBConnection.Query.encode(query, params, opts)
     catch
       kind, reason ->
-        stack = System.stacktrace()
+        stack = __STACKTRACE__
         raised_close(conn, query, meter, opts, kind, reason, stack)
     else
       params ->
@@ -1163,7 +1163,7 @@ defmodule DBConnection do
       DBConnection.EncodeError -> {:prepare, meter}
     catch
       kind, reason ->
-        stack = System.stacktrace()
+        stack = __STACKTRACE__
         {kind, reason, stack, meter}
     else
       params ->
@@ -1177,7 +1177,7 @@ defmodule DBConnection do
       DBConnection.Query.decode(query, result, opts)
     catch
       kind, reason ->
-        stack = System.stacktrace()
+        stack = __STACKTRACE__
         {kind, reason, stack, meter}
     else
       result ->
@@ -1384,7 +1384,7 @@ defmodule DBConnection do
       log(log, entry)
     catch
       kind, reason ->
-        stack = System.stacktrace()
+        stack = __STACKTRACE__
         log_raised(entry, kind, reason, stack)
     end
     log_result(result)
@@ -1440,7 +1440,7 @@ defmodule DBConnection do
             raise err
         end
       kind, reason ->
-        stack = System.stacktrace()
+        stack = __STACKTRACE__
         reset(conn)
         _ = rollback(conn, run, opts)
         :erlang.raise(kind, reason, stack)

--- a/lib/db_connection/connection.ex
+++ b/lib/db_connection/connection.ex
@@ -81,7 +81,7 @@ defmodule DBConnection.Connection do
       apply(mod, :connect, [connect_opts(opts)])
     rescue
       e ->
-        {e, stack} = maybe_sanitize_exception(e, System.stacktrace(), opts)
+        {e, stack} = maybe_sanitize_exception(e, __STACKTRACE__, opts)
         reraise e, stack
     else
       {:ok, state} when after_connect != nil ->

--- a/lib/db_connection/holder.ex
+++ b/lib/db_connection/holder.ex
@@ -316,7 +316,7 @@ defmodule DBConnection.Holder do
       apply(module, fun, args)
     catch
       kind, reason ->
-        {:catch, kind, reason, System.stacktrace()}
+        {:catch, kind, reason, __STACKTRACE__}
     else
       result when is_tuple(result) ->
         state = :erlang.element(:erlang.tuple_size(result), result)

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule DBConnection.Mixfile do
   def project do
     [app: :db_connection,
      version: @version,
-     elixir: "~> 1.6",
+     elixir: "~> 1.7",
      deps: deps(),
      docs: docs(),
      description: description(),


### PR DESCRIPTION
Replace deprecated `System.stacktrace()` by `__STACKTRACE__` to fix warnings in Elixir 1.11.
Bumped minimal elixir version accordingly to 1.7 (like ecto's [current release](https://github.com/elixir-ecto/ecto/blob/v3.4.6/mix.exs#L10))