### PR TITLE
Add `:connection_listeners` option to `DBConnection.start_link/2`

### DIFF
--- a/integration_test/cases/connection_listeners_test.exs
+++ b/integration_test/cases/connection_listeners_test.exs
@@ -1,0 +1,135 @@
+defmodule ConnectionListenersTest do
+  use ExUnit.Case, async: true
+
+  alias TestPool, as: P
+  alias TestAgent, as: A
+  alias TestQuery, as: Q
+
+  test "send `:connected` message after connected" do
+    stack = [
+      {:ok, :state}
+    ]
+
+    {:ok, agent} = A.start_link(stack)
+
+    opts = [agent: agent, parent: self(), connection_listeners: [self()]]
+    {:ok, _pool} = P.start_link(opts)
+
+    assert_receive {:connected, conn}
+    assert is_pid(conn)
+
+    refute_receive {:connected, _conn}
+    refute_receive {:disconnected, _conn}
+  end
+
+  test "send `:connected` message after connected with `after_connect` function" do
+    stack = [
+      {:ok, :state},
+      {:idle, :state},
+      :ok,
+      {:ok, :state2},
+      {:idle, :state},
+      :ok
+    ]
+
+    {:ok, agent} = A.start_link(stack)
+
+    parent = self()
+
+    after_connect = fn _ ->
+      send(parent, :after_connect)
+      :ok
+    end
+
+    opts = [
+      after_connect: after_connect,
+      agent: agent,
+      parent: self(),
+      connection_listeners: [self()]
+    ]
+
+    {:ok, _pool} = P.start_link(opts)
+
+    assert_receive {:connected, _conn}
+    assert_receive :after_connect
+  end
+
+  test "send `:disconnected` message after disconnect" do
+    err = RuntimeError.exception("oops")
+
+    stack = [
+      fn opts ->
+        send(opts[:parent], {:hi1, self()})
+        {:ok, :state}
+      end,
+      {:disconnect, err, :discon},
+      :ok,
+      {:error, err}
+    ]
+
+    {:ok, agent} = A.start_link(stack)
+
+    opts = [agent: agent, parent: self(), connection_listeners: [self()]]
+    {:ok, pool} = P.start_link(opts)
+
+    assert P.close(pool, %Q{})
+    assert_receive {:hi1, conn}
+    assert_receive {:connected, ^conn}
+    assert_receive {:disconnected, ^conn}
+    refute_receive {:connected, _conn}
+    refute_receive {:disconnected, _conn}
+  end
+
+  test "send `:connected` message after disconnect then reconnected" do
+    err = RuntimeError.exception("oops")
+
+    stack = [
+      fn opts ->
+        send(opts[:parent], {:hi1, self()})
+        {:ok, :state}
+      end,
+      {:disconnect, err, :discon},
+      :ok,
+      fn opts ->
+        send(opts[:parent], {:hi2, self()})
+        {:ok, :reconnected}
+      end
+    ]
+
+    {:ok, agent} = A.start_link(stack)
+
+    opts = [agent: agent, parent: self(), connection_listeners: [self()]]
+    {:ok, pool} = P.start_link(opts)
+
+    assert P.close(pool, %Q{})
+    assert_receive {:hi1, conn}
+    assert_receive {:connected, ^conn}
+    assert_receive {:disconnected, ^conn}
+    assert_receive {:hi2, ^conn}
+    assert_receive {:connected, ^conn}
+    refute_receive {:disconnected, _conn}
+    refute_receive {:connected, _conn}
+  end
+
+  test "send `:connected` message after each connection in pool has connected" do
+    stack = [
+      {:ok, :state},
+      {:ok, :state},
+      {:ok, :state}
+    ]
+
+    {:ok, agent} = A.start_link(stack)
+
+    opts = [agent: agent, parent: self(), connection_listeners: [self()], pool_size: 3]
+    {:ok, _pool} = P.start_link(opts)
+
+    assert_receive {:connected, conn1}
+    assert_receive {:connected, conn2}
+    assert_receive {:connected, conn3}
+    refute_receive {:connected, _conn}
+    assert is_pid(conn1)
+    assert is_pid(conn2)
+    assert is_pid(conn3)
+    refute conn1 == conn2 == conn3
+  end
+end

--- a/integration_test/tests.exs
+++ b/integration_test/tests.exs
@@ -1,5 +1,6 @@
 Code.require_file "cases/after_connect_test.exs", __DIR__
 Code.require_file "cases/connect_test.exs", __DIR__
+Code.require_file "cases/connection_listeners_test.exs", __DIR__
 Code.require_file "cases/client_test.exs", __DIR__
 Code.require_file "cases/close_test.exs", __DIR__
 Code.require_file "cases/execute_test.exs", __DIR__

--- a/lib/db_connection.ex
+++ b/lib/db_connection.ex
@@ -105,6 +105,7 @@ defmodule DBConnection do
   @type start_option ::
           {:after_connect, (t -> any) | {module, atom, [any]} | nil}
           | {:after_connect_timeout, timeout}
+          | {:connection_listeners, list(Process.dest()) | nil}
           | {:backoff_max, non_neg_integer}
           | {:backoff_min, non_neg_integer}
           | {:backoff_type, :stop | :exp | :rand | :rand_exp}
@@ -369,6 +370,9 @@ defmodule DBConnection do
     to `args` or `nil` (default: `nil`)
     * `:after_connect_timeout` - The maximum time allowed to perform
     function specified by `:after_connect` option (default: `15_000`)
+    * `:connection_listeners` - A list of process destinations to send
+      notification messages whenever a connection is connected or disconnected.
+      See "Connection listeners" below
     * `:name` - A name to register the started process (see the `:name` option
       in `GenServer.start_link/3`)
     * `:pool` - Chooses the pool to be started
@@ -410,6 +414,20 @@ defmodule DBConnection do
   requests before they are sent to the database, which would
   otherwise increase the burden on the database, making the
   overload worse.
+
+  ## Connection listeners
+
+  The `:connection_listeners` option allows one or more processes to be notified
+  whenever a connection is connected or disconnected. A listener may be a remote
+  or local PID, a local port, a locally registered name, or a tuple in the form
+  of `{registered_name, node}` for a registered name at another node.
+
+  Each listener process may receive the following messages where `pid` 
+  identifies the connection process.
+
+    * `{:connected, pid}`
+    * `{:disconnected, pid}`
+
   """
   @spec start_link(module, opts :: Keyword.t) :: GenServer.on_start
   def start_link(conn_mod, opts) do

--- a/lib/db_connection.ex
+++ b/lib/db_connection.ex
@@ -419,11 +419,11 @@ defmodule DBConnection do
 
   The `:connection_listeners` option allows one or more processes to be notified
   whenever a connection is connected or disconnected. A listener may be a remote
-  or local PID, a local port, a locally registered name, or a tuple in the form
-  of `{registered_name, node}` for a registered name at another node.
+  or local PID, a locally registered name, or a tuple in the form of
+  `{registered_name, node}` for a registered name at another node.
 
-  Each listener process may receive the following messages where `pid` 
-  identifies the connection process.
+  Each listener process may receive the following messages where `pid`
+  identifies the connection process:
 
     * `{:connected, pid}`
     * `{:disconnected, pid}`


### PR DESCRIPTION
The `:connection_listeners` option allows one or more processes to be notified whenever a connection is connected or disconnected. A listener may be a remote or local PID, a local port, a locally registered name, or a tuple in the form of `{registered_name, node}` for a registered name at another node.

Each listener process may receive the following messages where `pid` identifies the connection process:

* `{:connected, pid}`
* `{:disconnected, pid}`

Related to #227.

@josevalim Does this follow what you were initally suggesting?