### PR TITLE
feat: add telemetry event for queue timeouts

### DIFF
--- a/integration_test/cases/queue_test.exs
+++ b/integration_test/cases/queue_test.exs
@@ -171,10 +171,11 @@ defmodule QueueTest do
       %{count: 1},
       %{
         error: %DBConnection.ConnectionError{reason: :queue_timeout},
-        connection_listeners: [^test_pid],
-        pool: ^pool_type
+        opts: event_opts
       }
     }
+
+    assert opts ++ [pool: pool_type, pool_size: 1] == event_opts
   end
 
   test "queue handles holder that has been deleted" do

--- a/integration_test/cases/queue_test.exs
+++ b/integration_test/cases/queue_test.exs
@@ -133,8 +133,23 @@ defmodule QueueTest do
     stack = [{:ok, :state}, {:idle, :state}, {:idle, :state}, {:idle, :state}, {:idle, :state}]
     {:ok, agent} = A.start_link(stack)
 
-    opts = [agent: agent, parent: self(), backoff_start: 30_000,
-      queue_timeout: 10, queue_target: 10, queue_interval: 10]
+    test_pid = self()
+
+    opts = [agent: agent, parent: test_pid, backoff_start: 30_000,
+      queue_timeout: 10, queue_target: 10, queue_interval: 10, connection_listeners: [test_pid]
+    ]
+
+    event = [:db_connection, :connection_error]
+
+    :telemetry.attach(
+      "queue-timeout-handler",
+      event,
+      fn event, measurements, metadata, _ ->
+        send test_pid, {:event, event, measurements, metadata}
+      end,
+      nil
+    )
+
     {:ok, pool} = P.start_link(opts)
 
     P.run(pool, fn(_) ->
@@ -147,6 +162,19 @@ defmodule QueueTest do
     end)
 
     assert P.run(pool, fn(_) -> :hi end) == :hi
+
+    pool_type = P.pool_type()
+
+    assert_receive {
+      :event,
+      ^event,
+      %{count: 1},
+      %{
+        error: %DBConnection.ConnectionError{reason: :queue_timeout},
+        connection_listeners: [^test_pid],
+        pool: ^pool_type
+      }
+    }
   end
 
   test "queue handles holder that has been deleted" do

--- a/integration_test/connection_pool/test_helper.exs
+++ b/integration_test/connection_pool/test_helper.exs
@@ -7,4 +7,7 @@ Code.require_file("../../test/test_support.exs", __DIR__)
 
 defmodule TestPool do
   use TestConnection, pool: DBConnection.ConnectionPool, pool_size: 1
+
+  @doc false
+  def pool_type, do: DBConnection.ConnectionPool
 end

--- a/integration_test/ownership/test_helper.exs
+++ b/integration_test/ownership/test_helper.exs
@@ -10,4 +10,7 @@ Code.require_file("../../test/test_support.exs", __DIR__)
 
 defmodule TestPool do
   use TestConnection, pool: DBConnection.Ownership, pool_size: 1
+
+  @doc false
+  def pool_type, do: DBConnection.Ownership
 end

--- a/lib/db_connection.ex
+++ b/lib/db_connection.ex
@@ -424,6 +424,24 @@ defmodule DBConnection do
     * `{:connected, pid}`
     * `{:disconnected, pid}`
 
+  ## Telemetry
+
+  A `[:db_connection, :connection_error]` event is published whenever a connection checkout
+  receives a `%DBConnection.ConnectionError{}`.
+
+  Measurements:
+
+    * `:error` A fixed-value measurement which always measures 1.
+
+  Metadata
+
+    * `:connection_listeners` The list of connection listeners (as described above) passed to
+    the connection pool. Can be used to relay this event to the proper connection listeners.
+
+    * `:connection_error` The `DBConnection.ConnectionError` struct which triggered the event.
+
+    * `:pool` The connection pool in which this event was triggered.
+
   """
   @spec start_link(module, opts :: Keyword.t()) :: GenServer.on_start()
   def start_link(conn_mod, opts) do

--- a/lib/db_connection/holder.ex
+++ b/lib/db_connection/holder.ex
@@ -60,6 +60,19 @@ defmodule DBConnection.Holder do
       {:ok, _, _, _, _} = ok ->
         ok
 
+      {:error, %DBConnection.ConnectionError{} = connection_error} = error ->
+        :telemetry.execute(
+          [:db_connection, :connection_error],
+          %{count: 1},
+          %{
+            error: connection_error,
+            pool: opts[:pool],
+            connection_listeners: opts[:connection_listeners]
+          }
+        )
+
+        error
+
       {:error, _} = error ->
         error
 

--- a/lib/db_connection/holder.ex
+++ b/lib/db_connection/holder.ex
@@ -66,8 +66,7 @@ defmodule DBConnection.Holder do
           %{count: 1},
           %{
             error: connection_error,
-            pool: opts[:pool],
-            connection_listeners: opts[:connection_listeners]
+            opts: opts
           }
         )
 

--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule DBConnection.Mixfile do
 
   def application do
     [
-      applications: [:logger, :connection],
+      applications: [:logger, :connection, :telemetry],
       mod: {DBConnection.App, []}
     ]
   end
@@ -32,7 +32,8 @@ defmodule DBConnection.Mixfile do
   defp deps do
     [
       {:connection, "~> 1.0"},
-      {:ex_doc, ">= 0.0.0", only: :dev, runtime: false}
+      {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
+      {:telemetry, "~> 0.4"}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule DBConnection.Mixfile do
     [
       {:connection, "~> 1.0"},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
-      {:telemetry, "~> 0.4"}
+      {:telemetry, "~> 0.4 or ~> 1.0"}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule DBConnection.Mixfile do
 
   def application do
     [
-      applications: [:logger, :connection, :telemetry],
+      extra_applications: [:logger],
       mod: {DBConnection.App, []}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -5,4 +5,5 @@
   "makeup": {:hex, :makeup, "1.0.5", "d5a830bc42c9800ce07dd97fa94669dfb93d3bf5fcf6ea7a0c67b2e0e4a7f26c", [:mix], [{:nimble_parsec, "~> 0.5 or ~> 1.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "cfa158c02d3f5c0c665d0af11512fed3fba0144cf1aadee0f2ce17747fba2ca9"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.15.0", "98312c9f0d3730fde4049985a1105da5155bfe5c11e47bdc7406d88e01e4219b", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.1", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "75ffa34ab1056b7e24844c90bfc62aaf6f3a37a15faa76b07bc5eba27e4a8b4a"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
+  "telemetry": {:hex, :telemetry, "0.4.2", "2808c992455e08d6177322f14d3bdb6b625fbcfd233a73505870d8738a2f4599", [:rebar3], [], "hexpm", "2d1419bd9dda6a206d7b5852179511722e2b18812310d304620c7bd92a13fcef"},
 }


### PR DESCRIPTION
As discussed in #235 and #234, this PR adds a telemetry event for `DBConnection.ConnectionError`s.

There are some discussion points still:
1. Which `opts` should we add to `metadata`?
2. Is there any meaningful measurement we could add instead of `%{error: 1}`?
3. Although the tests pass as expected, when I used this code in a local project (pointing to the local path for `db_connection`), the `:connection_listeners` option is empty. Is this expected? This was the only way I could think of for monitoring a project with different `Ecto.Repo`s. Or maybe this event should be published by either `postgrex`, or `ecto_sql` or even `ecto`?

I chose to keep publishing the event basically in the same place as in #235 because the `opts` could be useful in handling multiple-Ecto.Repo projects.