### PR TITLE
Enable detecting connection type of a pool process

### DIFF
--- a/integration_test/connection_pool/test_helper.exs
+++ b/integration_test/connection_pool/test_helper.exs
@@ -4,10 +4,3 @@ ExUnit.start(
 )
 
 Code.require_file("../../test/test_support.exs", __DIR__)
-
-defmodule TestPool do
-  use TestConnection, pool: DBConnection.ConnectionPool, pool_size: 1
-
-  @doc false
-  def pool_type, do: DBConnection.ConnectionPool
-end

--- a/test/db_connection/connection_pool_test.exs
+++ b/test/db_connection/connection_pool_test.exs
@@ -1,0 +1,21 @@
+defmodule DBConnection.ConnectionPoolTest do
+  use ExUnit.Case, async: true
+
+  alias TestPool, as: P
+
+  describe "connection_module/1" do
+    test "returns the connection module when given a pool pid" do
+      {:ok, pool} = P.start_link([])
+      assert {:ok, TestConnection} = DBConnection.ConnectionPool.connection_module(pool)
+    end
+
+    test "returns the connection module when given a pool name", %{test: name} do
+      {:ok, _pool} = P.start_link(name: name)
+      assert {:ok, TestConnection} = DBConnection.ConnectionPool.connection_module(name)
+    end
+
+    test "returns an error if the given process is not a pool" do
+      assert :error = DBConnection.ConnectionPool.connection_module(self())
+    end
+  end
+end

--- a/test/test_support.exs
+++ b/test/test_support.exs
@@ -211,3 +211,10 @@ defmodule TestAgent do
     {next, {stack, [action | record]}}
   end
 end
+
+defmodule TestPool do
+  use TestConnection, pool: DBConnection.ConnectionPool, pool_size: 1
+
+  @doc false
+  def pool_type, do: DBConnection.ConnectionPool
+end


### PR DESCRIPTION
This allows for determining if the given process is a connection pool and also figure out the underlying driver.