### PR TITLE
Change disconnect_all log severity to debug

### DIFF
--- a/integration_test/connection_pool/disconnect_all_test.exs
+++ b/integration_test/connection_pool/disconnect_all_test.exs
@@ -28,7 +28,7 @@ defmodule TestPoolDisconnectAll do
     assert P.execute(pool, %Q{}, [:param]) == {:ok, %Q{}, %R{}}
     assert P.execute(pool, %Q{}, [:param]) == {:ok, %Q{}, %R{}}
 
-    err = %DBConnection.ConnectionError{message: "disconnect_all requested", severity: :info}
+    err = %DBConnection.ConnectionError{message: "disconnect_all requested", severity: :debug}
 
     assert [
              connect: [_],
@@ -69,7 +69,7 @@ defmodule TestPoolDisconnectAll do
     assert P.execute(pool, %Q{}, [:param]) == {:ok, %Q{}, %R{}}
     assert P.execute(pool, %Q{}, [:param]) == {:ok, %Q{}, %R{}}
 
-    err = %DBConnection.ConnectionError{message: "disconnect_all requested", severity: :info}
+    err = %DBConnection.ConnectionError{message: "disconnect_all requested", severity: :debug}
 
     assert [
              connect: [_],

--- a/integration_test/ownership/disconnect_all_test.exs
+++ b/integration_test/ownership/disconnect_all_test.exs
@@ -33,7 +33,7 @@ defmodule TestOwnershipDisconnectAll do
     assert P.execute(pool, %Q{}, [:param]) == {:ok, %Q{}, %R{}}
     assert P.execute(pool, %Q{}, [:param]) == {:ok, %Q{}, %R{}}
 
-    err = %DBConnection.ConnectionError{message: "disconnect_all requested", severity: :info}
+    err = %DBConnection.ConnectionError{message: "disconnect_all requested", severity: :debug}
 
     assert [
              connect: [_],

--- a/lib/db_connection/holder.ex
+++ b/lib/db_connection/holder.ex
@@ -258,7 +258,7 @@ defmodule DBConnection.Holder do
     _ -> false
   else
     true ->
-      opts = [message: "disconnect_all requested", severity: :info]
+      opts = [message: "disconnect_all requested", severity: :debug]
       handle_disconnect(holder, DBConnection.ConnectionError.exception(opts))
 
     false ->


### PR DESCRIPTION
Because `disconnect_all` is being explicitly called, the logging message doesn't need to be as verbose as it is. This changes the severity to debug. From @josevalim's [comment here](https://github.com/elixir-ecto/db_connection/issues/99#issuecomment-1058472198).