### PR TITLE
Alter functions to pass error tuple instead of raising errors

### DIFF
--- a/.trunk/.gitignore
+++ b/.trunk/.gitignore
@@ -1,0 +1,4 @@
+*out
+*logs
+plugins
+user_trunk.yaml

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,0 +1,10 @@
+version: 0.1
+cli:
+  version: 0.16.1-beta
+lint:
+  enabled:
+    - actionlint@1.6.15
+    - git-diff-check@SYSTEM
+    - gitleaks@8.10.3
+    - markdownlint@0.32.1
+    - prettier@2.7.1

--- a/lib/db_connection.ex
+++ b/lib/db_connection.ex
@@ -549,7 +549,12 @@ defmodule DBConnection do
   def prepare!(conn, query, opts \\ []) do
     case prepare(conn, query, opts) do
       {:ok, result} -> result
-      {:error, err} -> raise err
+      {:error, err} ->
+        if Application.get_env(:db_connection, :avoid_raising_connection_errors, false) do
+          raise err
+        else
+          {:error, err}
+        end
     end
   end
 
@@ -612,7 +617,12 @@ defmodule DBConnection do
   def prepare_execute!(conn, query, params, opts \\ []) do
     case prepare_execute(conn, query, params, opts) do
       {:ok, query, result} -> {query, result}
-      {:error, err} -> raise err
+      {:error, err} ->
+        if Application.get_env(:db_connection, :avoid_raising_connection_errors, false) do
+          raise err
+        else
+          {:error, err}
+        end
     end
   end
 
@@ -675,7 +685,12 @@ defmodule DBConnection do
   def execute!(conn, query, params, opts \\ []) do
     case execute(conn, query, params, opts) do
       {:ok, _query, result} -> result
-      {:error, err} -> raise err
+      {:error, err} ->
+        if Application.get_env(:db_connection, :avoid_raising_connection_errors, false) do
+          raise err
+        else
+          {:error, err}
+        end
     end
   end
 
@@ -724,7 +739,12 @@ defmodule DBConnection do
   def close!(conn, query, opts \\ []) do
     case close(conn, query, opts) do
       {:ok, result} -> result
-      {:error, err} -> raise err
+      {:error, err} ->
+        if Application.get_env(:db_connection, :avoid_raising_connection_errors, false) do
+          raise err
+        else
+          {:error, err}
+        end
     end
   end
 
@@ -799,14 +819,23 @@ defmodule DBConnection do
               )
 
             disconnect(conn, err)
-            raise err
+            # Here, we either raise or return an error tuple.
+            if Application.get_env(:db_connection, :avoid_raising_connection_errors, false) do
+              raise err
+            else
+              {:error, err}
+            end
 
           {_result, {kind, reason, stack, _meter}} ->
             :erlang.raise(kind, reason, stack)
         end
 
       {:error, err, _} ->
-        raise err
+        if Application.get_env(:db_connection, :avoid_raising_connection_errors, false) do
+          raise err
+        else
+          {:error, err}
+        end
 
       {kind, reason, stack, _} ->
         :erlang.raise(kind, reason, stack)
@@ -892,7 +921,11 @@ defmodule DBConnection do
         {:error, :rollback}
 
       {:error, err} ->
-        raise err
+        if Application.get_env(:db_connection, :avoid_raising_connection_errors, false) do
+          raise err
+        else
+          {:error, err}
+        end
     end
   end
 
@@ -905,7 +938,11 @@ defmodule DBConnection do
         {:error, :rollback}
 
       {:error, err} ->
-        raise err
+        if Application.get_env(:db_connection, :raise_errors, false) do
+          raise err
+        else
+          {:error, err}
+        end
     end
   end
 
@@ -1316,7 +1353,11 @@ defmodule DBConnection do
         {query, cursor}
 
       {:error, err} ->
-        raise err
+        if Application.get_env(:db_connection, :avoid_raising_connection_errors, false) do
+          raise err
+        else
+          {:error, err}
+        end
     end
   end
 
@@ -1580,7 +1621,11 @@ defmodule DBConnection do
             {:error, reason}
 
           {:error, err} ->
-            raise err
+            if Application.get_env(:db_connection, :avoid_raising_connection_errors, false) do
+              raise err
+            else
+              {:error, err}
+            end
         end
 
       kind, reason ->
@@ -1598,7 +1643,11 @@ defmodule DBConnection do
             {:error, :rollback}
 
           {:error, err} ->
-            raise err
+            if Application.get_env(:db_connection, :avoid_raising_connection_errors, false) do
+              raise err
+            else
+              {:error, err}
+            end
         end
     after
       reset(conn)
@@ -1758,7 +1807,11 @@ defmodule DBConnection do
         {[result], {ok, query, cursor}}
 
       {:error, err} ->
-        raise err
+        if Application.get_env(:db_connection, :avoid_raising_connection_errors, false) do
+          raise err
+        else
+          {:error, err}
+        end
     end
   end
 


### PR DESCRIPTION
As per #260 , we wanted a way to prevent raising errors and instead return error tuples.

I may be missing something - seeking some additional guidance to figure out what's needed to make it return error tuple instead of raising.

* Configuration - right now no clear pattern exists in `db_connection`. Either the configuration would have to be passed down to prevent raising, or have a simple `Application.get_env`, but keep sane defaults to raise. We do not want to disrupt [all consumers](https://hex.pm/packages?search=depends%3Ahexpm%3Adb_connection) of the `db_connection` library.
* All the consumers of `db_connection` would appear to need to adhere to raise vs error tuple, if indeed we did get this change in place.
* Tests around DBConnection (where the raise'ing happens) is very limited. My changes are quite fragile at the moment.
* Concerns around how to set up mocks/tests to get the raise/error tuples to trigger.
* By passing the tuples up, the call stack would receive unintended error tuples.
* An example Repo may have: `UserApplication.Repo -> Ecto.Repo -> Ecto.Adapters.Postgres -> Ecto.Repo.Schema -> Ecto.Adaptesr.SQL -> Ecto.Adapters.SQL.Connection -> Ecto.Adapters.Postgres.Connection -> DBConnection.execute`

Would love any feedback or suggestions the team would have. From where I sit, I would even think just overriding the userspace `Repo.insert` call to try/catch may be an easier fit over all. Happy to explore with the team!