### PR TITLE
Add example implementation for a connection_listener

### DIFF
--- a/lib/db_connection.ex
+++ b/lib/db_connection.ex
@@ -435,44 +435,44 @@ defmodule DBConnection do
 
   Here is an example of a `connection_listener` implementation:
 
-    defmodule DBConnectionListener do
-      use GenServer
+      defmodule DBConnectionListener do
+        use GenServer
 
-      @impl true
-      def init(stack) when is_list(stack) do
-        {:ok, stack}
-      end
+        def start_link(opts) do
+          GenServer.start_link(__MODULE__, [], opts)
+        end
 
-      @impl true
-      def handle_call(:read_state, _from, state) do
-        {:reply, state, state}
-      end
+        def get_notifications(pid) do
+          GenServer.call(pid, :read_state)
+        end
 
-      @impl true
-      def handle_info({:connected, _pid} = msg, state) do
-        {:noreply, [msg | state]}
-      end
+        @impl true
+        def init(stack) when is_list(stack) do
+          {:ok, stack}
+        end
 
-      @impl true
-      def handle_info({_other_states, _pid} = msg, state) do
-        {:noreply, [msg | state]}
-      end
+        @impl true
+        def handle_call(:read_state, _from, state) do
+          {:reply, state, state}
+        end
 
-      def start_link(opts) do
-        GenServer.start_link(__MODULE__, [], opts)
-      end
+        @impl true
+        def handle_info({:connected, _pid} = msg, state) do
+          {:noreply, [msg | state]}
+        end
 
-      def get_notifications(pid) do
-        GenServer.call(pid, :read_state)
+        @impl true
+        def handle_info({_other_states, _pid} = msg, state) do
+          {:noreply, [msg | state]}
+        end
       end
-    end
 
   You can then start it, pass it into a `DBConnection.start_link/1` and when needed
   can query the notifications:
 
-    {:ok, pid} = DBConnectionListener.start_link([])
-    {:ok, _conn} = DBConnection.start_link(SomeModule, [connection_listeners: [connection_listener]])
-    notifications = DBConnectionListener.get_notifications(pid)
+      {:ok, pid} = DBConnectionListener.start_link([])
+      {:ok, _conn} = DBConnection.start_link(SomeModule, [connection_listeners: [connection_listener]])
+      notifications = DBConnectionListener.get_notifications(pid)
 
   ## Telemetry
 

--- a/lib/db_connection.ex
+++ b/lib/db_connection.ex
@@ -438,10 +438,6 @@ defmodule DBConnection do
     defmodule DBConnectionListener do
       use GenServer
 
-      def start_link(opts) do
-        GenServer.start_link(__MODULE__, [], opts)
-      end
-
       @impl true
       def init(stack) when is_list(stack) do
         {:ok, stack}
@@ -460,6 +456,10 @@ defmodule DBConnection do
       @impl true
       def handle_info({_other_states, _pid} = msg, state) do
         {:noreply, [msg | state]}
+      end
+
+      def start_link(opts) do
+        GenServer.start_link(__MODULE__, [], opts)
       end
 
       def get_notifications(pid) do


### PR DESCRIPTION
Hi!

As usual, thank you for the work in this repo! I noticed we didn't have a small example implementation for a `connection_listener`. After playing around with some code, I arrived at the the one below think it may serve as a nice starting point for folks wanting to implement their own `connection_listeners`.

The simplest way I found to test/prove it worked was to add it to a test, I do it [here](https://github.com/pdgonzalez872/db_connection/commit/845c2aaf8be97c7e1b65e335a4c73f13e74478f9)

Hope this helps!