### PR TITLE
Format the integration_test directory

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,4 @@
 # Used by "mix format"
 [
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test,integration_test}/**/*.{ex,exs}"]
 ]

--- a/integration_test/cases/after_connect_test.exs
+++ b/integration_test/cases/after_connect_test.exs
@@ -14,28 +14,30 @@ defmodule AfterConnectTest do
       {:ok, %Q{}, %R{}, :newer_state},
       {:idle, :newer_state},
       {:ok, %Q{}, %R{}, :newest_state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
-    after_connect = fn(conn) ->
+    after_connect = fn conn ->
       _ = Process.put(:agent, agent)
       assert P.execute(conn, %Q{}, [:after_connect]) == {:ok, %Q{}, %R{}}
-      assert P.execute(conn, %Q{}, [:after_connect], [key: :value]) == {:ok, %Q{}, %R{}}
+      assert P.execute(conn, %Q{}, [:after_connect], key: :value) == {:ok, %Q{}, %R{}}
       :ok
     end
+
     opts = [after_connect: after_connect, agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
 
     assert P.execute(pool, %Q{}, [:client])
 
     assert [
-      connect: [_],
-      handle_status: _,
-      handle_execute: [%Q{}, [:after_connect], _, :state],
-      handle_execute: [%Q{}, [:after_connect],
-        [{:key, :value} | _], :new_state],
-      handle_status: _,
-      handle_execute: [%Q{}, [:client], _, :newer_state]] = A.record(agent)
+             connect: [_],
+             handle_status: _,
+             handle_execute: [%Q{}, [:after_connect], _, :state],
+             handle_execute: [%Q{}, [:after_connect], [{:key, :value} | _], :new_state],
+             handle_status: _,
+             handle_execute: [%Q{}, [:client], _, :newer_state]
+           ] = A.record(agent)
   end
 
   test "after_connect execute with mfargs" do
@@ -46,15 +48,16 @@ defmodule AfterConnectTest do
       {:ok, %Q{}, %R{}, :newer_state},
       {:idle, :newer_state},
       {:ok, %Q{}, %R{}, :newest_state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     defmodule AfterCon do
       def after_connect(conn, :arg, agent) do
         _ = Process.put(:agent, agent)
         assert P.execute(conn, %Q{}, [:after_connect]) == {:ok, %Q{}, %R{}}
-        assert P.execute(conn, %Q{}, [:after_connect], [key: :value]) == {:ok, %Q{}, %R{}}
-         :ok
+        assert P.execute(conn, %Q{}, [:after_connect], key: :value) == {:ok, %Q{}, %R{}}
+        :ok
       end
     end
 
@@ -66,13 +69,13 @@ defmodule AfterConnectTest do
       assert P.execute(pool, %Q{}, [:client])
 
       assert [
-        connect: [_],
-        handle_status: _,
-        handle_execute: [%Q{}, [:after_connect], _, :state],
-        handle_execute: [%Q{}, [:after_connect],
-          [{:key, :value} | _], :new_state],
-        handle_status: _,
-        handle_execute: [%Q{}, [:client], _, :newer_state]] = A.record(agent)
+               connect: [_],
+               handle_status: _,
+               handle_execute: [%Q{}, [:after_connect], _, :state],
+               handle_execute: [%Q{}, [:after_connect], [{:key, :value} | _], :new_state],
+               handle_status: _,
+               handle_execute: [%Q{}, [:client], _, :newer_state]
+             ] = A.record(agent)
     after
       :code.purge(AfterConn)
       :code.delete(AfterConn)
@@ -81,6 +84,7 @@ defmodule AfterConnectTest do
 
   test "after_connect execute error returns error" do
     err = RuntimeError.exception("oops")
+
     stack = [
       {:ok, :state},
       {:idle, :state},
@@ -88,31 +92,35 @@ defmodule AfterConnectTest do
       {:ok, %Q{}, %R{}, :newer_state},
       {:idle, :newer_state},
       {:ok, %Q{}, %R{}, :newest_state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
-    after_connect = fn(conn) ->
+    after_connect = fn conn ->
       _ = Process.put(:agent, agent)
       assert P.execute(conn, %Q{}, [:after_connect]) == {:error, err}
       assert P.execute(conn, %Q{}, [:after_connect]) == {:ok, %Q{}, %R{}}
       :ok
     end
+
     opts = [after_connect: after_connect, agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
 
     assert P.execute(pool, %Q{}, [:client])
 
     assert [
-      connect: [_],
-      handle_status: _,
-      handle_execute: [%Q{}, [:after_connect], _, :state],
-      handle_execute: [%Q{}, [:after_connect], _, :new_state],
-      handle_status: _,
-      handle_execute: [%Q{}, [:client], _, :newer_state]] = A.record(agent)
+             connect: [_],
+             handle_status: _,
+             handle_execute: [%Q{}, [:after_connect], _, :state],
+             handle_execute: [%Q{}, [:after_connect], _, :new_state],
+             handle_status: _,
+             handle_execute: [%Q{}, [:client], _, :newer_state]
+           ] = A.record(agent)
   end
 
   test "after_connect execute disconnect returns error" do
     err = RuntimeError.exception("oops")
+
     stack = [
       {:ok, :state},
       {:idle, :state},
@@ -123,22 +131,29 @@ defmodule AfterConnectTest do
       {:ok, %Q{}, %R{}, :new_state2},
       {:idle, :new_state2},
       {:ok, %Q{}, %R{}, :newer_state2}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
-    after_connect = fn(conn) ->
+
+    after_connect = fn conn ->
       send(parent, :after_connect)
       _ = Process.put(:agent, agent)
+
       case P.execute(conn, %Q{}, [:after_connect]) do
         {:error, ^err} ->
-          assert_raise DBConnection.Connection.Error, "connection is closed",
-            fn() -> P.execute(conn, %Q{}, [:after_connect]) end
+          assert_raise DBConnection.Connection.Error, "connection is closed", fn ->
+            P.execute(conn, %Q{}, [:after_connect])
+          end
+
           :ok
+
         {:ok, %Q{}, %R{}} ->
           :ok
       end
     end
+
     opts = [after_connect: after_connect, agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
 
@@ -147,40 +162,47 @@ defmodule AfterConnectTest do
     assert P.execute(pool, %Q{}, [:client])
 
     assert [
-      connect: [_],
-      handle_status: _,
-      handle_execute: [%Q{}, [:after_connect], _, :state],
-      disconnect: [^err, :new_state],
-      connect: [_],
-      handle_status: _,
-      handle_execute: [%Q{}, [:after_connect], _, :state2],
-      handle_status: _,
-      handle_execute: [%Q{}, [:client], _, :new_state2]] = A.record(agent)
+             connect: [_],
+             handle_status: _,
+             handle_execute: [%Q{}, [:after_connect], _, :state],
+             disconnect: [^err, :new_state],
+             connect: [_],
+             handle_status: _,
+             handle_execute: [%Q{}, [:after_connect], _, :state2],
+             handle_status: _,
+             handle_execute: [%Q{}, [:client], _, :new_state2]
+           ] = A.record(agent)
   end
 
   test "after_connect execute bad return raises DBConnection.ConnectionError" do
     stack = [
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], {:hi, self()})
         Process.link(opts[:parent])
         {:ok, :state}
       end,
       {:idle, :state},
       :oops,
-      fn(_) ->
+      fn _ ->
         :timer.sleep(:infinity)
       end
-     ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
-    after_connect = fn(conn) ->
+
+    after_connect = fn conn ->
       send(parent, {:after_connect, self()})
       _ = Process.put(:agent, agent)
-      assert_raise DBConnection.ConnectionError, "bad return value: :oops",
-        fn() -> P.execute(conn, %Q{}, [:after_connect]) end
+
+      assert_raise DBConnection.ConnectionError, "bad return value: :oops", fn ->
+        P.execute(conn, %Q{}, [:after_connect])
+      end
+
       :ok
     end
+
     opts = [after_connect: after_connect, agent: agent, parent: parent]
     Process.flag(:trap_exit, true)
     {:ok, _} = P.start_link(opts)
@@ -188,44 +210,52 @@ defmodule AfterConnectTest do
     assert_receive {:hi, conn}
 
     assert_receive {:after_connect, after_pid}
-    prefix = "client #{inspect after_pid} stopped: " <>
-      "** (DBConnection.ConnectionError) bad return value: :oops"
+
+    prefix =
+      "client #{inspect(after_pid)} stopped: " <>
+        "** (DBConnection.ConnectionError) bad return value: :oops"
+
     len = byte_size(prefix)
+
     assert_receive {:EXIT, ^conn,
-      {%DBConnection.ConnectionError{message: <<^prefix::binary-size(len), _::binary>>},
-        [_|_]}}
+                    {%DBConnection.ConnectionError{
+                       message: <<^prefix::binary-size(len), _::binary>>
+                     }, [_ | _]}}
 
     assert [
-      {:connect, _},
-      {:handle_status, _},
-      {:handle_execute, [%Q{}, [:after_connect], _, :state]}| _] = A.record(agent)
+             {:connect, _},
+             {:handle_status, _},
+             {:handle_execute, [%Q{}, [:after_connect], _, :state]} | _
+           ] = A.record(agent)
   end
 
   test "after_connect execute raise raises and stops connection" do
     stack = [
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], {:hi, self()})
         Process.link(opts[:parent])
         {:ok, :state}
       end,
       {:idle, :state},
-      fn(_, _, _, _) ->
+      fn _, _, _, _ ->
         raise "oops"
       end,
-      fn(_) ->
+      fn _ ->
         :timer.sleep(:infinity)
       end
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
-    after_connect = fn(conn) ->
+
+    after_connect = fn conn ->
       send(parent, {:after_connect, self()})
       _ = Process.put(:agent, agent)
-      assert_raise RuntimeError, "oops",
-        fn() -> P.execute(conn, %Q{}, [:after_connect]) end
+      assert_raise RuntimeError, "oops", fn -> P.execute(conn, %Q{}, [:after_connect]) end
       :ok
     end
+
     opts = [after_connect: after_connect, agent: agent, parent: parent]
     Process.flag(:trap_exit, true)
     {:ok, _} = P.start_link(opts)
@@ -233,27 +263,30 @@ defmodule AfterConnectTest do
     assert_receive {:hi, conn}
 
     assert_receive {:after_connect, after_pid}
-    prefix = "client #{inspect after_pid} stopped: ** (RuntimeError) oops"
+    prefix = "client #{inspect(after_pid)} stopped: ** (RuntimeError) oops"
     len = byte_size(prefix)
+
     assert_receive {:EXIT, ^conn,
-      {%DBConnection.ConnectionError{message: <<^prefix::binary-size(len), _::binary>>},
-       [_|_]}}
+                    {%DBConnection.ConnectionError{
+                       message: <<^prefix::binary-size(len), _::binary>>
+                     }, [_ | _]}}
 
     assert [
-      {:connect, _},
-      {:handle_status, _},
-      {:handle_execute, [%Q{}, [:after_connect], _, :state]}| _] = A.record(agent)
+             {:connect, _},
+             {:handle_status, _},
+             {:handle_execute, [%Q{}, [:after_connect], _, :state]} | _
+           ] = A.record(agent)
   end
 
   test "after_connect exit and reconnect" do
     stack = [
       {:ok, :state},
       {:idle, :state},
-      fn(_, _, _, _) ->
+      fn _, _, _, _ ->
         Process.exit(self(), :shutdown)
       end,
       :ok,
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], :reconnected)
         {:ok, :state2}
       end,
@@ -261,14 +294,16 @@ defmodule AfterConnectTest do
       {:ok, %Q{}, %R{}, :new_state2},
       {:idle, :new_state2},
       {:ok, %Q{}, %R{}, :newer_state2}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
-    after_connect = fn(conn) ->
+    after_connect = fn conn ->
       _ = Process.put(:agent, agent)
       assert P.execute(conn, %Q{}, [:after_connect]) == {:ok, %Q{}, %R{}}
       :ok
     end
+
     opts = [after_connect: after_connect, agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
 
@@ -276,16 +311,17 @@ defmodule AfterConnectTest do
     assert P.execute(pool, %Q{}, [:client]) == {:ok, %Q{}, %R{}}
 
     assert [
-      {:connect, _},
-      {:handle_status, _},
-      {:handle_execute, [%Q{}, [:after_connect], _, :state]},
-      {:disconnect, [%DBConnection.ConnectionError{}, :state]},
-      {:connect, _},
-      {:handle_status, _},
-      {:handle_execute, [%Q{}, [:after_connect], _, :state2]},
-      {:handle_status, _},
-      {:handle_execute, [%Q{}, [:client], _, :new_state2]}|
-      _] = A.record(agent)
+             {:connect, _},
+             {:handle_status, _},
+             {:handle_execute, [%Q{}, [:after_connect], _, :state]},
+             {:disconnect, [%DBConnection.ConnectionError{}, :state]},
+             {:connect, _},
+             {:handle_status, _},
+             {:handle_execute, [%Q{}, [:after_connect], _, :state2]},
+             {:handle_status, _},
+             {:handle_execute, [%Q{}, [:client], _, :new_state2]}
+             | _
+           ] = A.record(agent)
   end
 
   test "after_connect prepare" do
@@ -296,27 +332,30 @@ defmodule AfterConnectTest do
       {:ok, %Q{}, :newer_state},
       {:idle, :newer_state},
       {:ok, %Q{}, :newest_state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
-    after_connect = fn(conn) ->
+    after_connect = fn conn ->
       _ = Process.put(:agent, agent)
       assert P.prepare(conn, %Q{}) == {:ok, %Q{}}
-      assert P.prepare(conn, %Q{}, [key: :value]) == {:ok, %Q{}}
+      assert P.prepare(conn, %Q{}, key: :value) == {:ok, %Q{}}
       :ok
     end
+
     opts = [after_connect: after_connect, agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
 
     assert P.prepare(pool, %Q{})
 
     assert [
-      connect: [_],
-      handle_status: _,
-      handle_prepare: [%Q{}, _, :state],
-      handle_prepare: [%Q{}, [{:key, :value} | _], :new_state],
-      handle_status: _,
-      handle_prepare: [%Q{}, _, :newer_state]] = A.record(agent)
+             connect: [_],
+             handle_status: _,
+             handle_prepare: [%Q{}, _, :state],
+             handle_prepare: [%Q{}, [{:key, :value} | _], :new_state],
+             handle_status: _,
+             handle_prepare: [%Q{}, _, :newer_state]
+           ] = A.record(agent)
   end
 
   test "after_connect cancels timeout" do
@@ -325,10 +364,19 @@ defmodule AfterConnectTest do
       {:idle, :state},
       {:idle, :newer_state}
     ]
+
     {:ok, agent} = A.start_link(stack)
 
     after_connect = fn _conn -> :ok end
-    opts = [after_connect: after_connect, after_connect_timeout: 500, agent: agent, parent: self(), idle_interval: 10_000]
+
+    opts = [
+      after_connect: after_connect,
+      after_connect_timeout: 500,
+      agent: agent,
+      parent: self(),
+      idle_interval: 10_000
+    ]
+
     {:ok, _} = P.start_link(opts)
 
     # Wait until the after_connect could trigger by mistake

--- a/integration_test/cases/client_test.exs
+++ b/integration_test/cases/client_test.exs
@@ -11,34 +11,39 @@ defmodule ClientTest do
       {:ok, :state},
       {:idle, :state},
       :ok,
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], :reconnected)
         {:ok, :state}
       end,
       {:idle, :state},
-      {:idle, :state}]
+      {:idle, :state}
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
 
-    _ = spawn(fn() ->
-      _ = Process.put(:agent, agent)
-      P.run(pool, fn(_) ->
-        Process.exit(self(), :shutdown)
+    _ =
+      spawn(fn ->
+        _ = Process.put(:agent, agent)
+
+        P.run(pool, fn _ ->
+          Process.exit(self(), :shutdown)
+        end)
       end)
-    end)
 
     assert_receive :reconnected
-    assert P.run(pool, fn(_) -> :result end) == :result
+    assert P.run(pool, fn _ -> :result end) == :result
 
     assert [
-      {:connect, _},
-      {:handle_status, _},
-      {:disconnect, _},
-      {:connect, _},
-      {:handle_status, _},
-      {:handle_status, _}] = A.record(agent)
+             {:connect, _},
+             {:handle_status, _},
+             {:disconnect, _},
+             {:connect, _},
+             {:handle_status, _},
+             {:handle_status, _}
+           ] = A.record(agent)
   end
 
   test "reconnect when client timeout" do
@@ -46,61 +51,70 @@ defmodule ClientTest do
       {:ok, :state},
       {:idle, :state},
       :ok,
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], :reconnected)
         {:ok, :state}
       end,
       {:idle, :state},
       {:idle, :state},
-      {:idle, :state}]
+      {:idle, :state}
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
     opts = [agent: agent, parent: parent]
     {:ok, pool} = P.start_link(opts)
 
-    pid = spawn_link(fn() ->
-      _ = Process.put(:agent, agent)
-      assert_receive {:go, ^parent}
-      assert P.run(pool, fn(_) -> :result end) == :result
-      send(parent, {:done, self()})
-    end)
+    pid =
+      spawn_link(fn ->
+        _ = Process.put(:agent, agent)
+        assert_receive {:go, ^parent}
+        assert P.run(pool, fn _ -> :result end) == :result
+        send(parent, {:done, self()})
+      end)
 
-    P.run(pool, fn(conn) ->
-      assert_receive :reconnected
+    P.run(
+      pool,
+      fn conn ->
+        assert_receive :reconnected
 
-      assert {:error, %DBConnection.ConnectionError{}} =
-        P.execute(conn, %Q{}, [:first])
+        assert {:error, %DBConnection.ConnectionError{}} = P.execute(conn, %Q{}, [:first])
 
-      send(pid, {:go, parent})
-      assert_receive {:done, ^pid}
-    end, [timeout: 100])
+        send(pid, {:go, parent})
+        assert_receive {:done, ^pid}
+      end,
+      timeout: 100
+    )
 
     assert [
-      {:connect, _},
-      {:handle_status, _},
-      {:disconnect, _},
-      {:connect, _},
-      {:handle_status, _},
-      {:handle_status, _}] = A.record(agent)
+             {:connect, _},
+             {:handle_status, _},
+             {:disconnect, _},
+             {:connect, _},
+             {:handle_status, _},
+             {:handle_status, _}
+           ] = A.record(agent)
   end
 
   test "reconnect when client timeout and then returns ok even when disconnected" do
     stack = [
       {:ok, :state},
       {:idle, :state},
-      fn(_, _, _, _) ->
+      fn _, _, _, _ ->
         assert_receive :reconnected
         {:ok, %Q{}, %R{}, :new_state}
       end,
       :ok,
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], :reconnected)
         {:ok, :new_state}
       end,
       {:idle, :new_state},
       {:idle, :new_state},
-      {:ok, %Q{}, %R{}, :newer_state}]
+      {:ok, %Q{}, %R{}, :newer_state}
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
@@ -108,48 +122,55 @@ defmodule ClientTest do
     opts = [agent: agent, parent: parent]
     {:ok, pool} = P.start_link(opts)
 
-    assert P.run(pool, fn(conn) ->
-      assert {:ok, %Q{}, %R{}} =
-               P.execute(conn, %Q{}, [:first])
+    assert P.run(
+             pool,
+             fn conn ->
+               assert {:ok, %Q{}, %R{}} = P.execute(conn, %Q{}, [:first])
 
-      spawn_link(fn() ->
-        _ = Process.put(:agent, agent)
-        assert P.run(pool, fn(_) -> :result end) == :result
-        send(parent, :done)
-      end)
-      :result
-    end, [timeout: 100]) == :result
+               spawn_link(fn ->
+                 _ = Process.put(:agent, agent)
+                 assert P.run(pool, fn _ -> :result end) == :result
+                 send(parent, :done)
+               end)
+
+               :result
+             end,
+             timeout: 100
+           ) == :result
 
     assert_receive :done
     assert P.execute(pool, %Q{}, [:second]) == {:ok, %Q{}, %R{}}
 
     assert [
-      {:connect, _},
-      {:handle_status, _},
-      {:handle_execute, [%Q{}, [:first], _, :state]},
-      {:disconnect, _},
-      {:connect, _},
-      {:handle_status, _},
-      {:handle_status, _},
-      {:handle_execute, [%Q{}, [:second], _, :new_state]}] = A.record(agent)
+             {:connect, _},
+             {:handle_status, _},
+             {:handle_execute, [%Q{}, [:first], _, :state]},
+             {:disconnect, _},
+             {:connect, _},
+             {:handle_status, _},
+             {:handle_status, _},
+             {:handle_execute, [%Q{}, [:second], _, :new_state]}
+           ] = A.record(agent)
   end
 
   test "reconnect when client timeout and then returns error when disconnected" do
     stack = [
       {:ok, :state},
       {:idle, :state},
-      fn(_, _, _, _) ->
+      fn _, _, _, _ ->
         assert_receive :reconnected
         {:disconnect, DBConnection.ConnectionError.exception("oops"), :new_state}
       end,
       :ok,
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], :reconnected)
         {:ok, :new_state}
       end,
       {:idle, :new_state},
       {:idle, :new_state},
-      {:ok, %Q{}, %R{}, :newer_state}]
+      {:ok, %Q{}, %R{}, :newer_state}
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
@@ -157,49 +178,57 @@ defmodule ClientTest do
     opts = [agent: agent, parent: parent]
     {:ok, pool} = P.start_link(opts)
 
-    assert P.run(pool, fn(conn) ->
-      message =
-        "oops (the connection was closed by the pool, possibly due to a timeout or because the pool has been terminated)"
+    assert P.run(
+             pool,
+             fn conn ->
+               message =
+                 "oops (the connection was closed by the pool, possibly due to a timeout or because the pool has been terminated)"
 
-      assert {:error, %DBConnection.ConnectionError{message: ^message}} =
-               P.execute(conn, %Q{}, [:first])
+               assert {:error, %DBConnection.ConnectionError{message: ^message}} =
+                        P.execute(conn, %Q{}, [:first])
 
-      spawn_link(fn() ->
-        _ = Process.put(:agent, agent)
-        assert P.run(pool, fn(_) -> :result end) == :result
-        send(parent, :done)
-      end)
-      :result
-    end, [timeout: 100]) == :result
+               spawn_link(fn ->
+                 _ = Process.put(:agent, agent)
+                 assert P.run(pool, fn _ -> :result end) == :result
+                 send(parent, :done)
+               end)
+
+               :result
+             end,
+             timeout: 100
+           ) == :result
 
     assert_receive :done
     assert P.execute(pool, %Q{}, [:second]) == {:ok, %Q{}, %R{}}
 
     assert [
-      {:connect, _},
-      {:handle_status, _},
-      {:handle_execute, [%Q{}, [:first], _, :state]},
-      {:disconnect, _},
-      {:connect, _},
-      {:handle_status, _},
-      {:handle_status, _},
-      {:handle_execute, [%Q{}, [:second], _, :new_state]}] = A.record(agent)
+             {:connect, _},
+             {:handle_status, _},
+             {:handle_execute, [%Q{}, [:first], _, :state]},
+             {:disconnect, _},
+             {:connect, _},
+             {:handle_status, _},
+             {:handle_status, _},
+             {:handle_execute, [%Q{}, [:second], _, :new_state]}
+           ] = A.record(agent)
   end
 
   test "reconnect when client timeout and then crashes" do
     stack = [
       {:ok, :state},
       {:idle, :state},
-      fn(_, _, _, _) ->
+      fn _, _, _, _ ->
         throw(:oops)
       end,
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], :reconnected)
         {:ok, :new_state}
       end,
       {:idle, :new_state},
       {:idle, :new_state},
-      {:ok, %Q{}, %R{}, :newer_state}]
+      {:ok, %Q{}, %R{}, :newer_state}
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
@@ -208,15 +237,19 @@ defmodule ClientTest do
     {:ok, pool} = P.start_link(opts)
 
     try do
-      P.run(pool, fn(conn) ->
-        spawn_link(fn ->
-          _ = Process.put(:agent, agent)
-          assert P.run(pool, fn(_) -> :result end) == :result
-          send(parent, :done)
-        end)
+      P.run(
+        pool,
+        fn conn ->
+          spawn_link(fn ->
+            _ = Process.put(:agent, agent)
+            assert P.run(pool, fn _ -> :result end) == :result
+            send(parent, :done)
+          end)
 
-        P.execute(conn, %Q{}, [:first])
-      end, [timeout: 100])
+          P.execute(conn, %Q{}, [:first])
+        end,
+        timeout: 100
+      )
     catch
       :throw, :oops ->
         :ok
@@ -226,13 +259,14 @@ defmodule ClientTest do
     assert P.execute(pool, %Q{}, [:second]) == {:ok, %Q{}, %R{}}
 
     assert [
-      {:connect, _},
-      {:handle_status, _},
-      {:handle_execute, [%Q{}, [:first], _, :state]},
-      {:connect, _},
-      {:handle_status, _},
-      {:handle_status, _},
-      {:handle_execute, [%Q{}, [:second], _, :new_state]}] = A.record(agent)
+             {:connect, _},
+             {:handle_status, _},
+             {:handle_execute, [%Q{}, [:first], _, :state]},
+             {:connect, _},
+             {:handle_status, _},
+             {:handle_status, _},
+             {:handle_execute, [%Q{}, [:second], _, :new_state]}
+           ] = A.record(agent)
   end
 
   test "fails when using an outdated connection reference" do
@@ -241,7 +275,7 @@ defmodule ClientTest do
       {:idle, :state},
       {:idle, :state},
       {:idle, :new_state},
-      {:idle, :new_state},
+      {:idle, :new_state}
     ]
 
     {:ok, agent} = A.start_link(stack)
@@ -262,10 +296,11 @@ defmodule ClientTest do
     end)
 
     assert [
-      {:connect, _},
-      {:handle_status, _},
-      {:handle_status, _},
-      {:handle_status, _},
-      {:handle_status, _}] = A.record(agent)
+             {:connect, _},
+             {:handle_status, _},
+             {:handle_status, _},
+             {:handle_status, _},
+             {:handle_status, _}
+           ] = A.record(agent)
   end
 end

--- a/integration_test/cases/close_test.exs
+++ b/integration_test/cases/close_test.exs
@@ -10,34 +10,42 @@ defmodule CloseTest do
       {:ok, :state},
       {:ok, :result, :new_state},
       {:ok, :result, :new_state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
     assert P.close(pool, %Q{}) == {:ok, :result}
-    assert P.close(pool, %Q{}, [key: :value]) == {:ok, :result}
+    assert P.close(pool, %Q{}, key: :value) == {:ok, :result}
 
     assert [
-      connect: [_],
-      handle_close: [%Q{}, _, :state],
-      handle_close: [%Q{}, [{:key, :value} | _], :new_state]] = A.record(agent)
+             connect: [_],
+             handle_close: [%Q{}, _, :state],
+             handle_close: [%Q{}, [{:key, :value} | _], :new_state]
+           ] = A.record(agent)
   end
 
   test "close logs ok" do
     stack = [
       {:ok, :state},
-      {:ok, :result, :new_state},
-     ]
+      {:ok, :result, :new_state}
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
     opts = [agent: agent, parent: parent]
     {:ok, pool} = P.start_link(opts)
 
-    log = fn(entry) ->
-      assert %DBConnection.LogEntry{call: :close, query: %Q{},
-                                    params: nil, result: {:ok, :result}} = entry
+    log = fn entry ->
+      assert %DBConnection.LogEntry{
+               call: :close,
+               query: %Q{},
+               params: nil,
+               result: {:ok, :result}
+             } = entry
+
       assert is_integer(entry.pool_time)
       assert entry.pool_time >= 0
       assert is_integer(entry.connection_time)
@@ -45,20 +53,24 @@ defmodule CloseTest do
       assert is_nil(entry.decode_time)
       send(parent, :logged)
     end
-    assert P.close(pool, %Q{}, [log: log]) == {:ok, :result}
+
+    assert P.close(pool, %Q{}, log: log) == {:ok, :result}
     assert_received :logged
 
     assert [
-      connect: [_],
-      handle_close: [%Q{}, _, :state]] = A.record(agent)
+             connect: [_],
+             handle_close: [%Q{}, _, :state]
+           ] = A.record(agent)
   end
 
   test "close error returns error" do
     err = RuntimeError.exception("oops")
+
     stack = [
       {:ok, :state},
       {:error, err, :new_state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
@@ -66,25 +78,33 @@ defmodule CloseTest do
     assert P.close(pool, %Q{}) == {:error, err}
 
     assert [
-      connect: [_],
-      handle_close: [%Q{}, _, :state]] = A.record(agent)
+             connect: [_],
+             handle_close: [%Q{}, _, :state]
+           ] = A.record(agent)
   end
 
   test "close logs error" do
     err = RuntimeError.exception("oops")
+
     stack = [
       {:ok, :state},
       {:error, err, :new_state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
     opts = [agent: agent, parent: parent]
     {:ok, pool} = P.start_link(opts)
 
-    log = fn(entry) ->
-      assert %DBConnection.LogEntry{call: :close, query: %Q{},
-                                    params: nil, result: {:error, ^err}} = entry
+    log = fn entry ->
+      assert %DBConnection.LogEntry{
+               call: :close,
+               query: %Q{},
+               params: nil,
+               result: {:error, ^err}
+             } = entry
+
       assert is_integer(entry.pool_time)
       assert entry.pool_time >= 0
       assert is_integer(entry.connection_time)
@@ -92,25 +112,28 @@ defmodule CloseTest do
       assert is_nil(entry.decode_time)
       send(parent, :logged)
     end
-    assert P.close(pool, %Q{}, [log: log]) == {:error, err}
+
+    assert P.close(pool, %Q{}, log: log) == {:error, err}
     assert_received :logged
 
     assert [
-      connect: [_],
-      handle_close: [%Q{}, _, :state]] = A.record(agent)
+             connect: [_],
+             handle_close: [%Q{}, _, :state]
+           ] = A.record(agent)
   end
 
   test "close logs raise" do
     stack = [
-      fn(opts) ->
+      fn opts ->
         Process.link(opts[:parent])
         {:ok, :state}
       end,
-      fn(_, _, _) ->
+      fn _, _, _ ->
         raise "oops"
       end,
       {:ok, :state2}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
@@ -118,10 +141,14 @@ defmodule CloseTest do
     _ = Process.flag(:trap_exit, true)
     {:ok, pool} = P.start_link(opts)
 
-    log = fn(entry) ->
-      assert %DBConnection.LogEntry{call: :close, query: %Q{},
-                                    params: nil, result: {:error, err}} = entry
-      assert %DBConnection.ConnectionError{message: "an exception was raised: ** (RuntimeError) oops" <> _} = err
+    log = fn entry ->
+      assert %DBConnection.LogEntry{call: :close, query: %Q{}, params: nil, result: {:error, err}} =
+               entry
+
+      assert %DBConnection.ConnectionError{
+               message: "an exception was raised: ** (RuntimeError) oops" <> _
+             } = err
+
       assert is_integer(entry.pool_time)
       assert entry.pool_time >= 0
       assert is_integer(entry.connection_time)
@@ -129,30 +156,35 @@ defmodule CloseTest do
       assert is_nil(entry.decode_time)
       send(parent, :logged)
     end
-    assert_raise RuntimeError, "oops", fn() -> P.close(pool, %Q{}, [log: log]) end
+
+    assert_raise RuntimeError, "oops", fn -> P.close(pool, %Q{}, log: log) end
     assert_received :logged
-    assert_receive {:EXIT, _, {%DBConnection.ConnectionError{}, [_|_]}}
+    assert_receive {:EXIT, _, {%DBConnection.ConnectionError{}, [_ | _]}}
 
     assert [
-      {:connect, [_]},
-      {:handle_close, [%Q{}, _, :state]} | _] = A.record(agent)
+             {:connect, [_]},
+             {:handle_close, [%Q{}, _, :state]} | _
+           ] = A.record(agent)
   end
 
   test "close! error raises error" do
     err = RuntimeError.exception("oops")
+
     stack = [
       {:ok, :state},
       {:error, err, :new_state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
-    assert_raise RuntimeError, "oops", fn() -> P.close!(pool, %Q{}) end
+    assert_raise RuntimeError, "oops", fn -> P.close!(pool, %Q{}) end
 
     assert [
-      connect: [_],
-      handle_close: [%Q{}, _, :state]] = A.record(agent)
+             connect: [_],
+             handle_close: [%Q{}, _, :state]
+           ] = A.record(agent)
   end
 
   test "close in failed transaction" do
@@ -161,24 +193,26 @@ defmodule CloseTest do
       {:ok, :began, :new_state},
       {:ok, :result, :newer_state},
       {:ok, :rolledback, :newest_state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
 
-    assert P.transaction(pool, fn(conn) ->
-      assert P.transaction(conn, fn(conn2) ->
-        P.rollback(conn2, :oops)
-      end) == {:error, :oops}
+    assert P.transaction(pool, fn conn ->
+             assert P.transaction(conn, fn conn2 ->
+                      P.rollback(conn2, :oops)
+                    end) == {:error, :oops}
 
-      assert P.close(conn, %Q{}, opts) == {:ok, :result}
-    end) == {:error, :rollback}
+             assert P.close(conn, %Q{}, opts) == {:ok, :result}
+           end) == {:error, :rollback}
 
     assert [
-      connect: [_],
-      handle_begin: [_, :state],
-      handle_close: [%Q{}, _, :new_state],
-      handle_rollback: [_, :newer_state]] = A.record(agent)
+             connect: [_],
+             handle_begin: [_, :state],
+             handle_close: [%Q{}, _, :new_state],
+             handle_rollback: [_, :newer_state]
+           ] = A.record(agent)
   end
 end

--- a/integration_test/cases/connect_test.exs
+++ b/integration_test/cases/connect_test.exs
@@ -7,15 +7,18 @@ defmodule ConnectTest do
 
   test "backoff after failed initial connection attempt" do
     err = RuntimeError.exception("oops")
+
     stack = [
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], {:error, self()})
         {:error, err}
       end,
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], {:hi, self()})
         {:ok, :state}
-      end]
+      end
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self(), backoff_min: 10]
@@ -24,18 +27,20 @@ defmodule ConnectTest do
     assert_receive {:hi, ^conn}
 
     assert [
-      connect: [opts2],
-      connect: [opts2]] = A.record(agent)
+             connect: [opts2],
+             connect: [opts2]
+           ] = A.record(agent)
   end
 
   test "MatchError on connect doesn't leak sensitive data" do
     stack = [
-    fn(opts) ->
-      Process.link(Keyword.get(opts, :parent))
-      raise MatchError, term: :password
-    end,
-    {:ok, :state}
+      fn opts ->
+        Process.link(Keyword.get(opts, :parent))
+        raise MatchError, term: :password
+      end,
+      {:ok, :state}
     ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self(), backoff_min: 10]
@@ -46,15 +51,22 @@ defmodule ConnectTest do
 
   test "MatchError on connect leaks sensitive data when configured" do
     stack = [
-    fn(opts) ->
-      Process.link(Keyword.get(opts, :parent))
-      raise MatchError, term: :password
-    end,
-    {:ok, :state}
+      fn opts ->
+        Process.link(Keyword.get(opts, :parent))
+        raise MatchError, term: :password
+      end,
+      {:ok, :state}
     ]
+
     {:ok, agent} = A.start_link(stack)
 
-    opts = [agent: agent, parent: self(), backoff_min: 10, show_sensitive_data_on_connection_error: true]
+    opts = [
+      agent: agent,
+      parent: self(),
+      backoff_min: 10,
+      show_sensitive_data_on_connection_error: true
+    ]
+
     Process.flag(:trap_exit, true)
     {:ok, _} = P.start_link(opts)
     assert_receive {:EXIT, _, {%MatchError{}, [{_, _, 1, _} | _rest]}}
@@ -62,12 +74,13 @@ defmodule ConnectTest do
 
   test "ErlangError on connect doesn't leak sensitive data" do
     stack = [
-    fn(opts) ->
-      Process.link(Keyword.get(opts, :parent))
-      :erlang.error(:badarg, [:password])
-    end,
-    {:ok, :state}
+      fn opts ->
+        Process.link(Keyword.get(opts, :parent))
+        :erlang.error(:badarg, [:password])
+      end,
+      {:ok, :state}
     ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self(), backoff_min: 10]
@@ -76,18 +89,24 @@ defmodule ConnectTest do
     assert_receive {:EXIT, _, {%RuntimeError{}, [{_, _, 1, _} | _rest]}}
   end
 
-
   test "ErlangError on connect leaks sensitive data when configured" do
     stack = [
-    fn(opts) ->
-      Process.link(Keyword.get(opts, :parent))
-      :erlang.error(:badarg, [:password])
-    end,
-    {:ok, :state}
+      fn opts ->
+        Process.link(Keyword.get(opts, :parent))
+        :erlang.error(:badarg, [:password])
+      end,
+      {:ok, :state}
     ]
+
     {:ok, agent} = A.start_link(stack)
 
-    opts = [agent: agent, parent: self(), backoff_min: 10, show_sensitive_data_on_connection_error: true]
+    opts = [
+      agent: agent,
+      parent: self(),
+      backoff_min: 10,
+      show_sensitive_data_on_connection_error: true
+    ]
+
     Process.flag(:trap_exit, true)
     {:ok, _} = P.start_link(opts)
     assert_receive {:EXIT, _, {%ArgumentError{}, [{_, _, [:password], _} | _rest]}}
@@ -95,10 +114,12 @@ defmodule ConnectTest do
 
   test "lazy configure connection with module function and args" do
     stack = [
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], {:hello, opts[:ref]})
         {:ok, :state}
-      end]
+      end
+    ]
+
     {:ok, agent} = A.start_link(stack)
     ref = make_ref()
     extra_opts = [parent: self(), ref: ref]
@@ -110,10 +131,12 @@ defmodule ConnectTest do
 
   test "lazy configure connection with fun" do
     stack = [
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], {:hello, opts[:ref]})
         {:ok, :state}
-      end]
+      end
+    ]
+
     {:ok, agent} = A.start_link(stack)
     ref = make_ref()
     extra_opts = [parent: self(), ref: ref]
@@ -125,18 +148,21 @@ defmodule ConnectTest do
 
   test "backoff after disconnect and failed connection attempt" do
     err = RuntimeError.exception("oops")
+
     stack = [
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], {:hi1, self()})
         {:ok, :state}
       end,
       {:disconnect, err, :discon},
       :ok,
       {:error, err},
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], {:hi2, self()})
         {:ok, :reconnected}
-      end]
+      end
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self(), backoff_min: 10]
@@ -146,22 +172,26 @@ defmodule ConnectTest do
     assert_receive {:hi2, ^conn}
 
     assert [
-      connect: [opts2],
-      handle_close: _,
-      disconnect: [^err, :discon],
-      connect: [opts2],
-      connect: [opts2]] = A.record(agent)
+             connect: [opts2],
+             handle_close: _,
+             disconnect: [^err, :discon],
+             connect: [opts2],
+             connect: [opts2]
+           ] = A.record(agent)
   end
 
   test "backoff :stop exits on failed initial connection attempt" do
     err = RuntimeError.exception("oops")
+
     stack = [
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], {:error, self()})
         Process.link(opts[:parent])
         {:error, err}
       end,
-      {:ok, :state}]
+      {:ok, :state}
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self(), backoff_type: :stop]
@@ -175,15 +205,18 @@ defmodule ConnectTest do
 
   test "backoff :stop exits after disconnect without attempting to connect" do
     err = RuntimeError.exception("oops")
+
     stack = [
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], {:hi, self()})
         Process.link(opts[:parent])
         {:ok, :state}
       end,
       {:disconnect, err, :discon},
       :ok,
-      {:ok, :state}]
+      {:ok, :state}
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self(), backoff_type: :stop]
@@ -195,8 +228,9 @@ defmodule ConnectTest do
     assert_receive {:EXIT, ^conn, {:shutdown, ^err}}
 
     assert [
-      {:connect, [_]},
-      {:handle_close, _} | _] = A.record(agent)
+             {:connect, [_]},
+             {:handle_close, _} | _
+           ] = A.record(agent)
   end
 
   test "backoff after failed after_connect" do
@@ -207,14 +241,17 @@ defmodule ConnectTest do
       {:ok, :state2},
       {:idle, :state},
       :ok
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
-    after_connect = fn(_) ->
+
+    after_connect = fn _ ->
       send(parent, :after_connect)
       Process.exit(self(), :shutdown)
     end
+
     opts = [after_connect: after_connect, agent: agent, parent: self()]
     {:ok, _} = P.start_link(opts)
 
@@ -223,10 +260,11 @@ defmodule ConnectTest do
     assert_receive :after_connect, 500
 
     assert [
-      {:connect, [_]},
-      {:handle_status, _},
-      {:disconnect, [%DBConnection.ConnectionError{}, :state]},
-      {:connect, [_]},
-      {:handle_status, _} | _] = A.record(agent)
+             {:connect, [_]},
+             {:handle_status, _},
+             {:disconnect, [%DBConnection.ConnectionError{}, :state]},
+             {:connect, [_]},
+             {:handle_status, _} | _
+           ] = A.record(agent)
   end
 end

--- a/integration_test/cases/connection_listeners_test.exs
+++ b/integration_test/cases/connection_listeners_test.exs
@@ -121,7 +121,14 @@ defmodule ConnectionListenersTest do
 
     {:ok, agent} = A.start_link(stack)
 
-    opts = [agent: agent, parent: self(), connection_listeners: [self()], pool_size: 3, backoff_min: 1_000]
+    opts = [
+      agent: agent,
+      parent: self(),
+      connection_listeners: [self()],
+      pool_size: 3,
+      backoff_min: 1_000
+    ]
+
     {:ok, _pool} = P.start_link(opts)
 
     assert_receive {:connected, conn1}

--- a/integration_test/cases/execute_test.exs
+++ b/integration_test/cases/execute_test.exs
@@ -11,46 +11,49 @@ defmodule ExecuteTest do
       {:ok, :state},
       {:ok, %Q{}, %R{}, :new_state},
       {:ok, %Q{}, %R{}, :new_state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
     assert P.execute(pool, %Q{}, [:param]) == {:ok, %Q{}, %R{}}
-    assert P.execute(pool, %Q{}, [:param], [key: :value]) == {:ok, %Q{}, %R{}}
+    assert P.execute(pool, %Q{}, [:param], key: :value) == {:ok, %Q{}, %R{}}
 
     assert [
-      connect: [_],
-      handle_execute: [%Q{}, [:param], _, :state],
-      handle_execute: [%Q{}, [:param], [{:key, :value} | _], :new_state]
-      ] = A.record(agent)
+             connect: [_],
+             handle_execute: [%Q{}, [:param], _, :state],
+             handle_execute: [%Q{}, [:param], [{:key, :value} | _], :new_state]
+           ] = A.record(agent)
   end
 
   test "execute encodes params and decodes result" do
     stack = [
       {:ok, :state},
-      {:ok, %Q{}, %R{}, :new_state},
-      ]
+      {:ok, %Q{}, %R{}, :new_state}
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
 
-    opts2 = [encode: fn([:param]) -> :encoded end,
-             decode: fn(%R{}) -> :decoded end]
+    opts2 = [encode: fn [:param] -> :encoded end, decode: fn %R{} -> :decoded end]
     assert P.execute(pool, %Q{}, [:param], opts2) == {:ok, %Q{}, :decoded}
 
     assert [
-      connect: [_],
-      handle_execute: [_, :encoded, _, :state]] = A.record(agent)
+             connect: [_],
+             handle_execute: [_, :encoded, _, :state]
+           ] = A.record(agent)
   end
 
   test "execute reprepares query on encode error" do
     stack = [
       {:ok, :state},
       {:ok, %Q{state: :prepared}, :new_state},
-      {:ok, %Q{state: :executed}, %R{}, :newer_state},
-      ]
+      {:ok, %Q{state: :executed}, %R{}, :newer_state}
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parse_once = fn query ->
@@ -72,32 +75,36 @@ defmodule ExecuteTest do
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
 
-    opts = [parse: parse_once,
-            encode: fail_encode_once,
-            decode: fn(%R{}) -> :decoded end]
+    opts = [parse: parse_once, encode: fail_encode_once, decode: fn %R{} -> :decoded end]
     assert P.execute(pool, %Q{}, [:param], opts) == {:ok, %Q{state: :executed}, :decoded}
 
     assert [
-      connect: [_],
-      handle_prepare: [%Q{state: nil}, _, :state],
-      handle_execute: [%Q{state: :prepared}, :encoded, _, :new_state]] = A.record(agent)
+             connect: [_],
+             handle_prepare: [%Q{state: nil}, _, :state],
+             handle_execute: [%Q{state: :prepared}, :encoded, _, :new_state]
+           ] = A.record(agent)
   end
 
   test "execute logs result" do
     stack = [
       {:ok, :state},
-      {:ok, %Q{}, %R{}, :new_state},
-      ]
+      {:ok, %Q{}, %R{}, :new_state}
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
     opts = [agent: agent, parent: parent]
     {:ok, pool} = P.start_link(opts)
 
-    log = fn(entry) ->
-      assert %DBConnection.LogEntry{call: :execute, query: %Q{},
-                                    params: [:param],
-                                    result: {:ok, %Q{}, %R{}}} = entry
+    log = fn entry ->
+      assert %DBConnection.LogEntry{
+               call: :execute,
+               query: %Q{},
+               params: [:param],
+               result: {:ok, %Q{}, %R{}}
+             } = entry
+
       assert is_integer(entry.pool_time)
       assert entry.pool_time >= 0
       assert is_integer(entry.connection_time)
@@ -106,20 +113,24 @@ defmodule ExecuteTest do
       assert entry.decode_time >= 0
       send(parent, :logged)
     end
-    assert P.execute(pool, %Q{}, [:param], [log: log]) == {:ok, %Q{}, %R{}}
+
+    assert P.execute(pool, %Q{}, [:param], log: log) == {:ok, %Q{}, %R{}}
     assert_received :logged
 
     assert [
-      connect: [_],
-      handle_execute: [%Q{}, [:param], _, :state]] = A.record(agent)
+             connect: [_],
+             handle_execute: [%Q{}, [:param], _, :state]
+           ] = A.record(agent)
   end
 
   test "execute error returns error" do
     err = RuntimeError.exception("oops")
+
     stack = [
       {:ok, :state},
       {:error, err, :new_state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
@@ -127,25 +138,33 @@ defmodule ExecuteTest do
     assert P.execute(pool, %Q{}, [:param]) == {:error, err}
 
     assert [
-      connect: [_],
-      handle_execute: [%Q{}, [:param], _, :state]] = A.record(agent)
+             connect: [_],
+             handle_execute: [%Q{}, [:param], _, :state]
+           ] = A.record(agent)
   end
 
   test "execute logs error" do
     err = RuntimeError.exception("oops")
+
     stack = [
       {:ok, :state},
       {:error, err, :new_state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
     opts = [agent: agent, parent: parent]
     {:ok, pool} = P.start_link(opts)
-    log = fn(entry) ->
-      assert %DBConnection.LogEntry{call: :execute, query: %Q{},
-                                    params: [:param],
-                                    result: {:error, ^err}} = entry
+
+    log = fn entry ->
+      assert %DBConnection.LogEntry{
+               call: :execute,
+               query: %Q{},
+               params: [:param],
+               result: {:error, ^err}
+             } = entry
+
       assert is_integer(entry.pool_time)
       assert entry.pool_time >= 0
       assert is_integer(entry.connection_time)
@@ -153,36 +172,47 @@ defmodule ExecuteTest do
       assert is_nil(entry.decode_time)
       send(parent, :logged)
     end
-    assert P.execute(pool, %Q{}, [:param], [log: log]) == {:error, err}
+
+    assert P.execute(pool, %Q{}, [:param], log: log) == {:error, err}
     assert_received :logged
 
     assert [
-      connect: [_],
-      handle_execute: [%Q{}, [:param], _, :state]] = A.record(agent)
+             connect: [_],
+             handle_execute: [%Q{}, [:param], _, :state]
+           ] = A.record(agent)
   end
 
   test "execute logs raise" do
     stack = [
-      fn(opts) ->
+      fn opts ->
         Process.link(opts[:parent])
         {:ok, :state}
       end,
-      fn(_, _, _, _) ->
+      fn _, _, _, _ ->
         raise "oops"
       end,
       {:ok, :state2}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
     opts = [agent: agent, parent: parent]
     _ = Process.flag(:trap_exit, true)
     {:ok, pool} = P.start_link(opts)
-    log = fn(entry) ->
-      assert %DBConnection.LogEntry{call: :execute, query: %Q{},
-                                    params: [:param],
-                                    result: {:error, err}} = entry
-      assert %DBConnection.ConnectionError{message: "an exception was raised: ** (RuntimeError) oops" <> _} = err
+
+    log = fn entry ->
+      assert %DBConnection.LogEntry{
+               call: :execute,
+               query: %Q{},
+               params: [:param],
+               result: {:error, err}
+             } = entry
+
+      assert %DBConnection.ConnectionError{
+               message: "an exception was raised: ** (RuntimeError) oops" <> _
+             } = err
+
       assert is_integer(entry.pool_time)
       assert entry.pool_time >= 0
       assert is_integer(entry.connection_time)
@@ -190,45 +220,64 @@ defmodule ExecuteTest do
       assert is_nil(entry.decode_time)
       send(parent, :logged)
     end
-    assert_raise RuntimeError, "oops",
-      fn() -> P.execute(pool, %Q{}, [:param], [log: log]) end
+
+    assert_raise RuntimeError, "oops", fn -> P.execute(pool, %Q{}, [:param], log: log) end
     assert_received :logged
-    assert_receive {:EXIT, _, {%DBConnection.ConnectionError{}, [_|_]}}
+    assert_receive {:EXIT, _, {%DBConnection.ConnectionError{}, [_ | _]}}
 
     assert [
-      {:connect, [_]},
-      {:handle_execute, [%Q{}, [:param], _, :state]} | _] = A.record(agent)
+             {:connect, [_]},
+             {:handle_execute, [%Q{}, [:param], _, :state]} | _
+           ] = A.record(agent)
   end
 
   test "execute logs encode and decode raise" do
     stack = [
       {:ok, :state},
       {:ok, %Q{}, %R{}, :new_state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
     opts = [agent: agent, parent: parent]
     _ = Process.flag(:trap_exit, true)
     {:ok, pool} = P.start_link(opts)
-    log = fn(entry) ->
-      assert %DBConnection.LogEntry{call: :execute, query: %Q{},
-                                    params: [:param], result: {:error, err}} = entry
-      assert %DBConnection.ConnectionError{message: "an exception was raised: ** (RuntimeError) oops" <> _} = err
+
+    log = fn entry ->
+      assert %DBConnection.LogEntry{
+               call: :execute,
+               query: %Q{},
+               params: [:param],
+               result: {:error, err}
+             } = entry
+
+      assert %DBConnection.ConnectionError{
+               message: "an exception was raised: ** (RuntimeError) oops" <> _
+             } = err
+
       assert is_nil(entry.pool_time)
       assert is_nil(entry.connection_time)
       assert is_nil(entry.decode_time)
       send(parent, :logged)
     end
-    opts2 = [encode: fn([:param]) -> raise "oops" end, log: log]
-    assert_raise RuntimeError, "oops",
-      fn() -> P.execute(pool, %Q{}, [:param], opts2) end
+
+    opts2 = [encode: fn [:param] -> raise "oops" end, log: log]
+    assert_raise RuntimeError, "oops", fn -> P.execute(pool, %Q{}, [:param], opts2) end
     assert_received :logged
 
-    log = fn(entry) ->
-      assert %DBConnection.LogEntry{call: :execute, query: %Q{},
-                                    params: [:param], result: {:error, err}} = entry
-      assert %DBConnection.ConnectionError{message: "an exception was raised: ** (RuntimeError) oops" <> _} = err
+    log = fn entry ->
+      assert %DBConnection.LogEntry{
+               call: :execute,
+               query: %Q{},
+               params: [:param],
+               result: {:error, err}
+             } = entry
+
+      assert %DBConnection.ConnectionError{
+               message: "an exception was raised: ** (RuntimeError) oops" <> _
+             } = err
+
       assert is_integer(entry.pool_time)
       assert entry.pool_time >= 0
       assert is_integer(entry.connection_time)
@@ -237,45 +286,50 @@ defmodule ExecuteTest do
       assert entry.decode_time >= 0
       send(parent, :logged)
     end
-    opts3 = [decode: fn(%R{}) -> raise "oops" end, log: log]
-    assert_raise RuntimeError, "oops",
-      fn() -> P.execute(pool, %Q{}, [:param], opts3) end
+
+    opts3 = [decode: fn %R{} -> raise "oops" end, log: log]
+    assert_raise RuntimeError, "oops", fn -> P.execute(pool, %Q{}, [:param], opts3) end
     assert_received :logged
 
     assert [
-      connect: [_],
-      handle_execute: [%Q{}, [:param], _, :state]] = A.record(agent)
+             connect: [_],
+             handle_execute: [%Q{}, [:param], _, :state]
+           ] = A.record(agent)
   end
 
   test "execute! error raises error" do
     err = RuntimeError.exception("oops")
+
     stack = [
       {:ok, :state},
       {:error, err, :new_state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
-    assert_raise RuntimeError, "oops",
-      fn() -> P.execute!(pool, %Q{}, [:param]) end
+    assert_raise RuntimeError, "oops", fn -> P.execute!(pool, %Q{}, [:param]) end
 
     assert [
-      connect: [_],
-      handle_execute: [%Q{}, [:param], _, :state]] = A.record(agent)
+             connect: [_],
+             handle_execute: [%Q{}, [:param], _, :state]
+           ] = A.record(agent)
   end
 
   test "execute disconnect returns error" do
     err = RuntimeError.exception("oops")
+
     stack = [
       {:ok, :state},
       {:disconnect, err, :new_state},
       :ok,
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], :reconnected)
         {:ok, :state}
       end
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
@@ -285,22 +339,24 @@ defmodule ExecuteTest do
     assert_receive :reconnected
 
     assert [
-      connect: [opts2],
-      handle_execute: [%Q{}, [:param], _, :state],
-      disconnect: [^err, :new_state],
-      connect: [opts2]] = A.record(agent)
+             connect: [opts2],
+             handle_execute: [%Q{}, [:param], _, :state],
+             disconnect: [^err, :new_state],
+             connect: [opts2]
+           ] = A.record(agent)
   end
 
   test "execute bad return raises DBConnection.ConnectionError and stops" do
     stack = [
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], {:hi, self()})
         Process.link(opts[:parent])
         {:ok, :state}
       end,
       :oops,
       {:ok, :state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
@@ -308,33 +364,41 @@ defmodule ExecuteTest do
     assert_receive {:hi, conn}
 
     Process.flag(:trap_exit, true)
-    assert_raise DBConnection.ConnectionError, "bad return value: :oops",
-      fn() -> P.execute(pool, %Q{}, [:param]) end
 
-    prefix = "client #{inspect self()} stopped: " <>
-      "** (DBConnection.ConnectionError) bad return value: :oops"
+    assert_raise DBConnection.ConnectionError, "bad return value: :oops", fn ->
+      P.execute(pool, %Q{}, [:param])
+    end
+
+    prefix =
+      "client #{inspect(self())} stopped: " <>
+        "** (DBConnection.ConnectionError) bad return value: :oops"
+
     len = byte_size(prefix)
+
     assert_receive {:EXIT, ^conn,
-      {%DBConnection.ConnectionError{message: <<^prefix::binary-size(len), _::binary>>},
-        [_|_]}}
+                    {%DBConnection.ConnectionError{
+                       message: <<^prefix::binary-size(len), _::binary>>
+                     }, [_ | _]}}
 
     assert [
-      {:connect, _},
-      {:handle_execute, [%Q{}, [:param], _, :state]}| _] = A.record(agent)
+             {:connect, _},
+             {:handle_execute, [%Q{}, [:param], _, :state]} | _
+           ] = A.record(agent)
   end
 
   test "execute raise raises and stops connection" do
     stack = [
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], {:hi, self()})
         Process.link(opts[:parent])
         {:ok, :state}
       end,
-      fn(_, _, _, _) ->
+      fn _, _, _, _ ->
         raise "oops"
       end,
       {:ok, :state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
@@ -342,17 +406,19 @@ defmodule ExecuteTest do
     assert_receive {:hi, conn}
 
     Process.flag(:trap_exit, true)
-    assert_raise RuntimeError, "oops",
-      fn() -> P.execute(pool, %Q{}, [:param]) end
+    assert_raise RuntimeError, "oops", fn -> P.execute(pool, %Q{}, [:param]) end
 
-    prefix = "client #{inspect self()} stopped: ** (RuntimeError) oops"
+    prefix = "client #{inspect(self())} stopped: ** (RuntimeError) oops"
     len = byte_size(prefix)
+
     assert_receive {:EXIT, ^conn,
-      {%DBConnection.ConnectionError{message: <<^prefix::binary-size(len), _::binary>>},
-       [_|_]}}
+                    {%DBConnection.ConnectionError{
+                       message: <<^prefix::binary-size(len), _::binary>>
+                     }, [_ | _]}}
 
     assert [
-      {:connect, _},
-      {:handle_execute, [%Q{}, [:param], _, :state]}| _] = A.record(agent)
+             {:connect, _},
+             {:handle_execute, [%Q{}, [:param], _, :state]} | _
+           ] = A.record(agent)
   end
 end

--- a/integration_test/cases/idle_test.exs
+++ b/integration_test/cases/idle_test.exs
@@ -24,7 +24,7 @@ defmodule TestIdle do
     assert P.execute(pool, %Q{}, [:param1]) == {:ok, %Q{}, %R{}}
     Process.sleep(10)
 
-    log = fn(entry) ->
+    log = fn entry ->
       assert %DBConnection.LogEntry{} = entry
       assert is_integer(entry.idle_time)
       assert entry.idle_time > 0
@@ -37,7 +37,7 @@ defmodule TestIdle do
     assert [
              connect: [_],
              handle_execute: _,
-             handle_execute: _,
+             handle_execute: _
            ] = A.record(agent)
   end
 
@@ -127,7 +127,14 @@ defmodule TestIdle do
     {:ok, agent1} = A.start_link(stack)
     {:ok, agent2} = A.start_link(stack)
 
-    opts = [agent: [agent1, agent2], parent: self(), idle_interval: 100, idle_limit: limit, pool_size: 2]
+    opts = [
+      agent: [agent1, agent2],
+      parent: self(),
+      idle_interval: 100,
+      idle_limit: limit,
+      pool_size: 2
+    ]
+
     {:ok, pool} = P.start_link(opts)
     assert_receive {:hi, conn1}
     assert_receive {:hi, conn2}

--- a/integration_test/cases/prepare_test.exs
+++ b/integration_test/cases/prepare_test.exs
@@ -10,71 +10,78 @@ defmodule PrepareTest do
       {:ok, :state},
       {:ok, %Q{state: :prepared}, :new_state},
       {:ok, %Q{state: :prepared}, :new_state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
     assert P.prepare(pool, %Q{}) == {:ok, %Q{state: :prepared}}
-    assert P.prepare(pool, %Q{}, [key: :value]) == {:ok, %Q{state: :prepared}}
+    assert P.prepare(pool, %Q{}, key: :value) == {:ok, %Q{state: :prepared}}
 
     assert [
-      connect: [_],
-      handle_prepare: [%Q{}, _, :state],
-      handle_prepare: [%Q{}, [{:key, :value} | _], :new_state]
-      ] = A.record(agent)
+             connect: [_],
+             handle_prepare: [%Q{}, _, :state],
+             handle_prepare: [%Q{}, [{:key, :value} | _], :new_state]
+           ] = A.record(agent)
   end
 
   test "prepare parses query" do
     stack = [
       {:ok, :state},
       {:ok, %Q{state: :prepared}, :new_state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
 
-    opts2 = [parse: fn(%Q{}) -> %Q{state: :parsed} end]
+    opts2 = [parse: fn %Q{} -> %Q{state: :parsed} end]
     assert P.prepare(pool, %Q{}, opts2) == {:ok, %Q{state: :prepared}}
 
     assert [
-      connect: [_],
-      handle_prepare: [%Q{state: :parsed}, _, :state]] = A.record(agent)
+             connect: [_],
+             handle_prepare: [%Q{state: :parsed}, _, :state]
+           ] = A.record(agent)
   end
 
   test "prepare describes query" do
     stack = [
       {:ok, :state},
       {:ok, %Q{}, :new_state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
 
-    opts2 = [describe: fn(%Q{}) -> %Q{state: :described} end]
+    opts2 = [describe: fn %Q{} -> %Q{state: :described} end]
     assert P.prepare(pool, %Q{}, opts2) == {:ok, %Q{state: :described}}
 
     assert [
-      connect: [_],
-      handle_prepare: [%Q{}, _, :state]] = A.record(agent)
+             connect: [_],
+             handle_prepare: [%Q{}, _, :state]
+           ] = A.record(agent)
   end
 
   test "prepare logs result" do
     stack = [
       {:ok, :state},
-      {:ok, %Q{}, :new_state},
-      ]
+      {:ok, %Q{}, :new_state}
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
     opts = [agent: agent, parent: parent]
     {:ok, pool} = P.start_link(opts)
 
-    log = fn(entry) ->
-      assert %DBConnection.LogEntry{call: :prepare, query: %Q{},
-                                    params: nil, result: {:ok, %Q{}}} = entry
+    log = fn entry ->
+      assert %DBConnection.LogEntry{call: :prepare, query: %Q{}, params: nil, result: {:ok, %Q{}}} =
+               entry
+
       assert is_integer(entry.pool_time)
       assert entry.pool_time >= 0
       assert is_integer(entry.connection_time)
@@ -82,20 +89,24 @@ defmodule PrepareTest do
       assert is_nil(entry.decode_time)
       send(parent, :logged)
     end
-    assert P.prepare(pool, %Q{}, [log: log]) == {:ok, %Q{}}
+
+    assert P.prepare(pool, %Q{}, log: log) == {:ok, %Q{}}
     assert_received :logged
 
     assert [
-      connect: [_],
-      handle_prepare: [%Q{}, _, :state]] = A.record(agent)
+             connect: [_],
+             handle_prepare: [%Q{}, _, :state]
+           ] = A.record(agent)
   end
 
   test "prepare error returns error" do
     err = RuntimeError.exception("oops")
+
     stack = [
       {:ok, :state},
       {:error, err, :new_state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
@@ -103,24 +114,33 @@ defmodule PrepareTest do
     assert P.prepare(pool, %Q{}) == {:error, err}
 
     assert [
-      connect: [_],
-      handle_prepare: [%Q{}, _, :state]] = A.record(agent)
+             connect: [_],
+             handle_prepare: [%Q{}, _, :state]
+           ] = A.record(agent)
   end
 
   test "prepare logs error" do
     err = RuntimeError.exception("oops")
+
     stack = [
       {:ok, :state},
       {:error, err, :new_state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
     opts = [agent: agent, parent: parent]
     {:ok, pool} = P.start_link(opts)
-    log = fn(entry) ->
-      assert %DBConnection.LogEntry{call: :prepare, query: %Q{},
-                                    params: nil, result: {:error, ^err}} = entry
+
+    log = fn entry ->
+      assert %DBConnection.LogEntry{
+               call: :prepare,
+               query: %Q{},
+               params: nil,
+               result: {:error, ^err}
+             } = entry
+
       assert is_integer(entry.pool_time)
       assert entry.pool_time >= 0
       assert is_integer(entry.connection_time)
@@ -128,35 +148,47 @@ defmodule PrepareTest do
       assert is_nil(entry.decode_time)
       send(parent, :logged)
     end
-    assert P.prepare(pool, %Q{}, [log: log]) == {:error, err}
+
+    assert P.prepare(pool, %Q{}, log: log) == {:error, err}
     assert_received :logged
 
     assert [
-      connect: [_],
-      handle_prepare: [%Q{}, _, :state]] = A.record(agent)
+             connect: [_],
+             handle_prepare: [%Q{}, _, :state]
+           ] = A.record(agent)
   end
 
   test "prepare logs raise" do
     stack = [
-      fn(opts) ->
+      fn opts ->
         Process.link(opts[:parent])
         {:ok, :state}
       end,
-      fn(_, _, _) ->
+      fn _, _, _ ->
         raise "oops"
       end,
       {:ok, :state2}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
     opts = [agent: agent, parent: parent]
     _ = Process.flag(:trap_exit, true)
     {:ok, pool} = P.start_link(opts)
-    log = fn(entry) ->
-      assert %DBConnection.LogEntry{call: :prepare, query: %Q{},
-                                    params: nil, result: {:error, err}} = entry
-      assert %DBConnection.ConnectionError{message: "an exception was raised: ** (RuntimeError) oops" <> _} = err
+
+    log = fn entry ->
+      assert %DBConnection.LogEntry{
+               call: :prepare,
+               query: %Q{},
+               params: nil,
+               result: {:error, err}
+             } = entry
+
+      assert %DBConnection.ConnectionError{
+               message: "an exception was raised: ** (RuntimeError) oops" <> _
+             } = err
+
       assert is_integer(entry.pool_time)
       assert entry.pool_time >= 0
       assert is_integer(entry.connection_time)
@@ -164,14 +196,15 @@ defmodule PrepareTest do
       assert is_nil(entry.decode_time)
       send(parent, :logged)
     end
-    assert_raise RuntimeError, "oops",
-      fn() -> P.prepare(pool, %Q{}, [log: log]) end
+
+    assert_raise RuntimeError, "oops", fn -> P.prepare(pool, %Q{}, log: log) end
     assert_received :logged
-    assert_receive {:EXIT, _, {%DBConnection.ConnectionError{}, [_|_]}}
+    assert_receive {:EXIT, _, {%DBConnection.ConnectionError{}, [_ | _]}}
 
     assert [
-      {:connect, [_]},
-      {:handle_prepare, [%Q{}, _, :state]} | _] = A.record(agent)
+             {:connect, [_]},
+             {:handle_prepare, [%Q{}, _, :state]} | _
+           ] = A.record(agent)
   end
 
   test "prepare logs parse and describe raise" do
@@ -179,30 +212,48 @@ defmodule PrepareTest do
       {:ok, :state},
       {:ok, %Q{}, :new_state},
       {:ok, :result, :newer_state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
     opts = [agent: agent, parent: parent]
     {:ok, pool} = P.start_link(opts)
-    log = fn(entry) ->
-      assert %DBConnection.LogEntry{call: :prepare, query: %Q{},
-                                    params: nil, result: {:error, err}} = entry
-      assert %DBConnection.ConnectionError{message: "an exception was raised: ** (RuntimeError) oops" <> _} = err
+
+    log = fn entry ->
+      assert %DBConnection.LogEntry{
+               call: :prepare,
+               query: %Q{},
+               params: nil,
+               result: {:error, err}
+             } = entry
+
+      assert %DBConnection.ConnectionError{
+               message: "an exception was raised: ** (RuntimeError) oops" <> _
+             } = err
+
       assert is_nil(entry.pool_time)
       assert is_nil(entry.connection_time)
       assert is_nil(entry.decode_time)
       send(parent, :logged)
     end
-    opts2 = [parse: fn(%Q{}) -> raise "oops" end, log: log]
-    assert_raise RuntimeError, "oops",
-      fn() -> P.prepare(pool, %Q{}, opts2) end
+
+    opts2 = [parse: fn %Q{} -> raise "oops" end, log: log]
+    assert_raise RuntimeError, "oops", fn -> P.prepare(pool, %Q{}, opts2) end
     assert_received :logged
 
-    log = fn(entry) ->
-      assert %DBConnection.LogEntry{call: :prepare, query: %Q{},
-                                    params: nil, result: {:error, err}} = entry
-      assert %DBConnection.ConnectionError{message: "an exception was raised: ** (RuntimeError) oops" <> _} = err
+    log = fn entry ->
+      assert %DBConnection.LogEntry{
+               call: :prepare,
+               query: %Q{},
+               params: nil,
+               result: {:error, err}
+             } = entry
+
+      assert %DBConnection.ConnectionError{
+               message: "an exception was raised: ** (RuntimeError) oops" <> _
+             } = err
+
       assert is_integer(entry.pool_time)
       assert entry.pool_time >= 0
       assert is_integer(entry.connection_time)
@@ -210,31 +261,35 @@ defmodule PrepareTest do
       assert is_nil(entry.decode_time)
       send(parent, :logged)
     end
-    opts3 = [describe: fn(%Q{}) -> raise "oops" end, log: log]
-    assert_raise RuntimeError, "oops",
-      fn() -> P.prepare(pool, %Q{}, opts3) end
+
+    opts3 = [describe: fn %Q{} -> raise "oops" end, log: log]
+    assert_raise RuntimeError, "oops", fn -> P.prepare(pool, %Q{}, opts3) end
     assert_received :logged
 
     assert [
-      connect: [_],
-      handle_prepare: [%Q{}, _, :state],
-      handle_close: [%Q{}, _, :new_state]] = A.record(agent)
+             connect: [_],
+             handle_prepare: [%Q{}, _, :state],
+             handle_close: [%Q{}, _, :new_state]
+           ] = A.record(agent)
   end
 
   test "prepare! error raises error" do
     err = RuntimeError.exception("oops")
+
     stack = [
       {:ok, :state},
       {:error, err, :new_state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
-    assert_raise RuntimeError, "oops", fn() -> P.prepare!(pool, %Q{}) end
+    assert_raise RuntimeError, "oops", fn -> P.prepare!(pool, %Q{}) end
 
     assert [
-      connect: [_],
-      handle_prepare: [%Q{}, _, :state]] = A.record(agent)
+             connect: [_],
+             handle_prepare: [%Q{}, _, :state]
+           ] = A.record(agent)
   end
 end

--- a/integration_test/cases/stream_test.exs
+++ b/integration_test/cases/stream_test.exs
@@ -17,27 +17,29 @@ defmodule StreamTest do
       {:halt, %R{}, :state2},
       {:ok, :deallocated, :new_state2},
       {:ok, :committed, :newer_state2}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
-    assert P.transaction(pool, fn(conn) ->
-      stream = P.stream(conn, %Q{}, [:param])
-      assert %DBConnection.Stream{} = stream
-      assert Enum.to_list(stream) == [%R{}, %R{}]
-      :hi
-    end) == {:ok, :hi}
+
+    assert P.transaction(pool, fn conn ->
+             stream = P.stream(conn, %Q{}, [:param])
+             assert %DBConnection.Stream{} = stream
+             assert Enum.to_list(stream) == [%R{}, %R{}]
+             :hi
+           end) == {:ok, :hi}
 
     assert [
-      connect: [_],
-      handle_begin: [_, :state],
-      handle_declare: [%Q{}, [:param], _, :new_state],
-      handle_fetch: [%Q{}, %C{}, _, :newer_state],
-      handle_fetch: [%Q{}, %C{}, _, :newest_state],
-      handle_deallocate: [%Q{}, %C{}, _, :state2],
-      handle_commit: [_, :new_state2]
-      ] = A.record(agent)
+             connect: [_],
+             handle_begin: [_, :state],
+             handle_declare: [%Q{}, [:param], _, :new_state],
+             handle_fetch: [%Q{}, %C{}, _, :newer_state],
+             handle_fetch: [%Q{}, %C{}, _, :newest_state],
+             handle_deallocate: [%Q{}, %C{}, _, :state2],
+             handle_commit: [_, :new_state2]
+           ] = A.record(agent)
   end
 
   test "stream encodes params and decodes result" do
@@ -48,28 +50,28 @@ defmodule StreamTest do
       {:halt, %R{}, :newest_state},
       {:ok, :deallocated, :state2},
       {:ok, :committed, :new_state2}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
 
-    assert P.transaction(pool, fn(conn) ->
-      opts2 = [encode: fn([:param]) -> :encoded end,
-               decode: fn(%R{}) -> :decoded end]
-      stream = P.stream(conn, %Q{}, [:param], opts2)
-      assert Enum.to_list(stream) == [:decoded]
-      :hi
-    end) == {:ok, :hi}
+    assert P.transaction(pool, fn conn ->
+             opts2 = [encode: fn [:param] -> :encoded end, decode: fn %R{} -> :decoded end]
+             stream = P.stream(conn, %Q{}, [:param], opts2)
+             assert Enum.to_list(stream) == [:decoded]
+             :hi
+           end) == {:ok, :hi}
 
     assert [
-      connect: [_],
-      handle_begin: [_, :state],
-      handle_declare: [_, :encoded, _, :new_state],
-      handle_fetch: [%Q{}, %C{}, _, :newer_state],
-      handle_deallocate: [%Q{}, %C{}, _, :newest_state],
-      handle_commit: [_, :state2]
-      ] = A.record(agent)
+             connect: [_],
+             handle_begin: [_, :state],
+             handle_declare: [_, :encoded, _, :new_state],
+             handle_fetch: [%Q{}, %C{}, _, :newer_state],
+             handle_deallocate: [%Q{}, %C{}, _, :newest_state],
+             handle_commit: [_, :state2]
+           ] = A.record(agent)
   end
 
   test "stream reprepares query on encode error" do
@@ -81,7 +83,8 @@ defmodule StreamTest do
       {:halt, %R{}, :newest_state},
       {:ok, :deallocated, :state2},
       {:ok, :committed, :new_state2}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parse_once = fn query ->
@@ -103,24 +106,27 @@ defmodule StreamTest do
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
 
-    assert P.transaction(pool, fn(conn) ->
-      opts2 = [parse: parse_once,
+    assert P.transaction(pool, fn conn ->
+             opts2 = [
+               parse: parse_once,
                encode: fail_encode_once,
-               decode: fn(%R{}) -> :decoded end]
-      stream = P.stream(conn, %Q{}, [:param], opts2)
-      assert Enum.to_list(stream) == [:decoded]
-      :hi
-    end) == {:ok, :hi}
+               decode: fn %R{} -> :decoded end
+             ]
+
+             stream = P.stream(conn, %Q{}, [:param], opts2)
+             assert Enum.to_list(stream) == [:decoded]
+             :hi
+           end) == {:ok, :hi}
 
     assert [
-      connect: [_],
-      handle_begin: [_, :state],
-      handle_prepare: [%Q{state: nil}, _, :begin_state],
-      handle_declare: [%Q{state: :prepared}, :encoded, _, :new_state],
-      handle_fetch: [%Q{state: :declared}, %C{}, _, :newer_state],
-      handle_deallocate: [%Q{}, %C{}, _, :newest_state],
-      handle_commit: [_, :state2]
-      ] = A.record(agent)
+             connect: [_],
+             handle_begin: [_, :state],
+             handle_prepare: [%Q{state: nil}, _, :begin_state],
+             handle_declare: [%Q{state: :prepared}, :encoded, _, :new_state],
+             handle_fetch: [%Q{state: :declared}, %C{}, _, :newer_state],
+             handle_deallocate: [%Q{}, %C{}, _, :newest_state],
+             handle_commit: [_, :state2]
+           ] = A.record(agent)
   end
 
   test "stream logs result" do
@@ -131,17 +137,19 @@ defmodule StreamTest do
       {:cont, %R{}, :newest_state},
       {:ok, :result, :state2},
       {:ok, :committed, :new_state2}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
     opts = [agent: agent, parent: parent]
     {:ok, pool} = P.start_link(opts)
-    assert P.transaction(pool, fn(conn) ->
-      stream = P.stream(conn, %Q{}, [:param], [log: &send(parent, &1)])
-      assert Enum.take(stream, 1) == [%R{}]
-      :hi
-    end) == {:ok, :hi}
+
+    assert P.transaction(pool, fn conn ->
+             stream = P.stream(conn, %Q{}, [:param], log: &send(parent, &1))
+             assert Enum.take(stream, 1) == [%R{}]
+             :hi
+           end) == {:ok, :hi}
 
     assert_received %DBConnection.LogEntry{call: :declare} = entry
     assert %{query: %Q{}, params: [:param], result: {:ok, %Q{}, %C{}}} = entry
@@ -166,34 +174,36 @@ defmodule StreamTest do
     assert is_nil(entry.decode_time)
 
     assert [
-      connect: [_],
-      handle_begin: [_, :state],
-      handle_declare: [%Q{}, [:param], _, :new_state],
-      handle_fetch: [%Q{}, %C{}, _, :newer_state],
-      handle_deallocate: [%Q{}, %C{}, _, :newest_state],
-      handle_commit: [_, :state2]
-      ] = A.record(agent)
+             connect: [_],
+             handle_begin: [_, :state],
+             handle_declare: [%Q{}, [:param], _, :new_state],
+             handle_fetch: [%Q{}, %C{}, _, :newer_state],
+             handle_deallocate: [%Q{}, %C{}, _, :newest_state],
+             handle_commit: [_, :state2]
+           ] = A.record(agent)
   end
 
   test "stream logs declare error" do
     err = RuntimeError.exception("oops")
+
     stack = [
       {:ok, :state},
       {:ok, :began, :new_state},
       {:error, err, :newer_state},
       {:ok, :committed, :newest_state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
     opts = [agent: agent, parent: parent]
     {:ok, pool} = P.start_link(opts)
 
-    assert P.transaction(pool, fn(conn) ->
-      stream = P.stream(conn, %Q{}, [:param], [log: &send(parent, &1)])
-      assert_raise RuntimeError, "oops",  fn() -> Enum.take(stream, 1) end
-      :hi
-    end) == {:ok, :hi}
+    assert P.transaction(pool, fn conn ->
+             stream = P.stream(conn, %Q{}, [:param], log: &send(parent, &1))
+             assert_raise RuntimeError, "oops", fn -> Enum.take(stream, 1) end
+             :hi
+           end) == {:ok, :hi}
 
     assert_received %DBConnection.LogEntry{call: :declare} = entry
     assert %{query: %Q{}, params: [:param], result: {:error, ^err}} = entry
@@ -203,72 +213,76 @@ defmodule StreamTest do
     assert is_nil(entry.decode_time)
 
     assert [
-      connect: [_],
-      handle_begin: [_, :state],
-      handle_declare: [%Q{}, [:param], _, :new_state],
-      handle_commit: [_, :newer_state],
-      ] = A.record(agent)
+             connect: [_],
+             handle_begin: [_, :state],
+             handle_declare: [%Q{}, [:param], _, :new_state],
+             handle_commit: [_, :newer_state]
+           ] = A.record(agent)
   end
 
   test "stream declare disconnects" do
     err = RuntimeError.exception("oops")
+
     stack = [
       {:ok, :state},
       {:ok, :began, :new_state},
       {:disconnect, err, :newer_state},
       :ok,
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], :reconnected)
         {:ok, :state2}
       end
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
     opts = [agent: agent, parent: parent]
     {:ok, pool} = P.start_link(opts)
 
-    assert P.transaction(pool, fn(conn) ->
-      stream = P.stream(conn, %Q{}, [:param])
-      assert_raise RuntimeError, "oops",  fn() -> Enum.take(stream, 1) end
-      :hi
-    end) == {:error, :rollback}
+    assert P.transaction(pool, fn conn ->
+             stream = P.stream(conn, %Q{}, [:param])
+             assert_raise RuntimeError, "oops", fn -> Enum.take(stream, 1) end
+             :hi
+           end) == {:error, :rollback}
 
     assert_receive :reconnected
 
     assert [
-      connect: [_],
-      handle_begin: [_, :state],
-      handle_declare: [%Q{}, [:param], _, :new_state],
-      disconnect: [^err, :newer_state],
-      connect: [_]
-      ] = A.record(agent)
+             connect: [_],
+             handle_begin: [_, :state],
+             handle_declare: [%Q{}, [:param], _, :new_state],
+             disconnect: [^err, :newer_state],
+             connect: [_]
+           ] = A.record(agent)
   end
 
   test "stream logs first disconnects" do
     err = RuntimeError.exception("oops")
+
     stack = [
       {:ok, :state},
       {:ok, :began, :new_state},
       {:ok, %Q{}, %C{}, :newer_state},
       {:disconnect, err, :newest_state},
       :ok,
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], :reconnected)
         {:ok, :state2}
       end
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
     opts = [agent: agent, parent: parent]
     {:ok, pool} = P.start_link(opts)
 
-    assert P.transaction(pool, fn(conn) ->
-      stream = P.stream(conn, %Q{}, [:param], [log: &send(parent, &1)])
-      assert_raise RuntimeError, "oops",  fn() -> Enum.take(stream, 1) end
-      :hi
-    end) == {:error, :rollback}
+    assert P.transaction(pool, fn conn ->
+             stream = P.stream(conn, %Q{}, [:param], log: &send(parent, &1))
+             assert_raise RuntimeError, "oops", fn -> Enum.take(stream, 1) end
+             :hi
+           end) == {:error, :rollback}
 
     assert_received %DBConnection.LogEntry{call: :declare}
 
@@ -289,16 +303,16 @@ defmodule StreamTest do
     assert_receive :reconnected
 
     assert [
-      connect: [_],
-      handle_begin: [_, :state],
-      handle_declare: [%Q{}, [:param], _, :new_state],
-      handle_fetch: [%Q{}, %C{}, _, :newer_state],
-      disconnect: [^err, :newest_state],
-      connect: [_]
-      ] = A.record(agent)
+             connect: [_],
+             handle_begin: [_, :state],
+             handle_declare: [%Q{}, [:param], _, :new_state],
+             handle_fetch: [%Q{}, %C{}, _, :newer_state],
+             disconnect: [^err, :newest_state],
+             connect: [_]
+           ] = A.record(agent)
   end
 
- test "stream deallocates after transaction failed" do
+  test "stream deallocates after transaction failed" do
     stack = [
       {:ok, :state},
       {:ok, :began, :new_state},
@@ -306,33 +320,38 @@ defmodule StreamTest do
       {:cont, %R{}, :newest_state},
       {:ok, :deallocated, :state2},
       {:ok, :rolledback, :new_state2}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
     opts = [agent: agent, parent: parent]
     {:ok, pool} = P.start_link(opts)
 
-    assert P.transaction(pool, fn(conn) ->
-      stream = P.stream(conn, %Q{}, [:param], [log: &send(parent, &1)])
-      catch_throw(Enum.map(stream, fn(%R{}) ->
-        {:error, :oops} = P.transaction(conn, &P.rollback(&1, :oops))
-        throw(:escape)
-      end))
-    end) == {:error, :rollback}
+    assert P.transaction(pool, fn conn ->
+             stream = P.stream(conn, %Q{}, [:param], log: &send(parent, &1))
+
+             catch_throw(
+               Enum.map(stream, fn %R{} ->
+                 {:error, :oops} = P.transaction(conn, &P.rollback(&1, :oops))
+                 throw(:escape)
+               end)
+             )
+           end) == {:error, :rollback}
 
     assert [
-      connect: [_],
-      handle_begin: [_, :state],
-      handle_declare: [%Q{}, [:param], _, :new_state],
-      handle_fetch: [%Q{}, %C{}, _, :newer_state],
-      handle_deallocate: [%Q{}, %C{}, _, :newest_state],
-      handle_rollback: [_, :state2]
-      ] = A.record(agent)
+             connect: [_],
+             handle_begin: [_, :state],
+             handle_declare: [%Q{}, [:param], _, :new_state],
+             handle_fetch: [%Q{}, %C{}, _, :newer_state],
+             handle_deallocate: [%Q{}, %C{}, _, :newest_state],
+             handle_rollback: [_, :state2]
+           ] = A.record(agent)
   end
 
   test "stream logs deallocate disconnect" do
     err = RuntimeError.exception("oops")
+
     stack = [
       {:ok, :state},
       {:ok, :began, :new_state},
@@ -340,22 +359,23 @@ defmodule StreamTest do
       {:cont, %R{}, :newest_state},
       {:disconnect, err, :state2},
       :ok,
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], :reconnected)
         {:ok, :state2}
       end
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
     opts = [agent: agent, parent: parent]
     {:ok, pool} = P.start_link(opts)
 
-    assert P.transaction(pool, fn(conn) ->
-      stream = P.stream(conn, %Q{}, [:param], [log: &send(parent, &1)])
-      assert Enum.take(stream, 1) == [%R{}]
-      :hi
-    end) == {:error, :rollback}
+    assert P.transaction(pool, fn conn ->
+             stream = P.stream(conn, %Q{}, [:param], log: &send(parent, &1))
+             assert Enum.take(stream, 1) == [%R{}]
+             :hi
+           end) == {:error, :rollback}
 
     assert_received %DBConnection.LogEntry{call: :declare}
     assert_received %DBConnection.LogEntry{call: :fetch}
@@ -370,19 +390,19 @@ defmodule StreamTest do
     assert_receive :reconnected
 
     assert [
-      connect: [_],
-      handle_begin: [_, :state],
-      handle_declare: [%Q{}, [:param], _, :new_state],
-      handle_fetch: [%Q{}, %C{}, _, :newer_state],
-      handle_deallocate: [%Q{}, %C{}, _, :newest_state],
-      disconnect: [^err, :state2],
-      connect: [_]
-      ] = A.record(agent)
+             connect: [_],
+             handle_begin: [_, :state],
+             handle_declare: [%Q{}, [:param], _, :new_state],
+             handle_fetch: [%Q{}, %C{}, _, :newer_state],
+             handle_deallocate: [%Q{}, %C{}, _, :newest_state],
+             disconnect: [^err, :state2],
+             connect: [_]
+           ] = A.record(agent)
   end
 
   test "stream declare bad return raises and stops" do
     stack = [
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], {:hi, self()})
         Process.link(opts[:parent])
         {:ok, :state}
@@ -390,7 +410,8 @@ defmodule StreamTest do
       {:ok, :began, :new_state},
       :oops,
       {:ok, :state2}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
@@ -399,39 +420,49 @@ defmodule StreamTest do
     assert_receive {:hi, conn}
 
     Process.flag(:trap_exit, true)
-    assert P.transaction(pool, fn(conn) ->
-      stream = P.stream(conn, %Q{}, [:param])
-      assert_raise DBConnection.ConnectionError, "bad return value: :oops",
-        fn() -> Enum.to_list(stream) end
-      :hi
-    end) == {:error, :rollback}
 
-    prefix = "client #{inspect self()} stopped: " <>
-      "** (DBConnection.ConnectionError) bad return value: :oops"
+    assert P.transaction(pool, fn conn ->
+             stream = P.stream(conn, %Q{}, [:param])
+
+             assert_raise DBConnection.ConnectionError, "bad return value: :oops", fn ->
+               Enum.to_list(stream)
+             end
+
+             :hi
+           end) == {:error, :rollback}
+
+    prefix =
+      "client #{inspect(self())} stopped: " <>
+        "** (DBConnection.ConnectionError) bad return value: :oops"
+
     len = byte_size(prefix)
+
     assert_receive {:EXIT, ^conn,
-      {%DBConnection.ConnectionError{message: <<^prefix::binary-size(len), _::binary>>},
-        [_|_]}}
+                    {%DBConnection.ConnectionError{
+                       message: <<^prefix::binary-size(len), _::binary>>
+                     }, [_ | _]}}
 
     assert [
-      {:connect, _},
-      {:handle_begin, [_, :state]},
-      {:handle_declare, [%Q{}, [:param], _, :new_state]} | _] = A.record(agent)
+             {:connect, _},
+             {:handle_begin, [_, :state]},
+             {:handle_declare, [%Q{}, [:param], _, :new_state]} | _
+           ] = A.record(agent)
   end
 
   test "stream declare raise raises and stops connection" do
     stack = [
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], {:hi, self()})
         Process.link(opts[:parent])
         {:ok, :state}
       end,
       {:ok, :began, :new_state},
-      fn(_, _, _, _) ->
+      fn _, _, _, _ ->
         raise "oops"
       end,
       {:ok, :state2}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
@@ -440,22 +471,26 @@ defmodule StreamTest do
     assert_receive {:hi, conn}
 
     Process.flag(:trap_exit, true)
-    assert P.transaction(pool, fn(conn) ->
-      stream = P.stream(conn, %Q{}, [:param])
-      assert_raise RuntimeError, "oops", fn() -> Enum.to_list(stream) end
-      :hi
-    end) == {:error, :rollback}
 
-    prefix = "client #{inspect self()} stopped: ** (RuntimeError) oops"
+    assert P.transaction(pool, fn conn ->
+             stream = P.stream(conn, %Q{}, [:param])
+             assert_raise RuntimeError, "oops", fn -> Enum.to_list(stream) end
+             :hi
+           end) == {:error, :rollback}
+
+    prefix = "client #{inspect(self())} stopped: ** (RuntimeError) oops"
     len = byte_size(prefix)
+
     assert_receive {:EXIT, ^conn,
-      {%DBConnection.ConnectionError{message: <<^prefix::binary-size(len), _::binary>>},
-        [_|_]}}
+                    {%DBConnection.ConnectionError{
+                       message: <<^prefix::binary-size(len), _::binary>>
+                     }, [_ | _]}}
 
     assert [
-      {:connect, _},
-      {:handle_begin, [_, :state]},
-      {:handle_declare, [%Q{}, [:param], _, :new_state]} | _] = A.record(agent)
+             {:connect, _},
+             {:handle_begin, [_, :state]},
+             {:handle_declare, [%Q{}, [:param], _, :new_state]} | _
+           ] = A.record(agent)
   end
 
   test "stream declare log raises and continues" do
@@ -466,35 +501,38 @@ defmodule StreamTest do
       {:halt, %R{}, :newest_state},
       {:ok, :deallocated, :state2},
       {:ok, :committed, :new_state2}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
     opts = [agent: agent, parent: parent]
     {:ok, pool} = P.start_link(opts)
 
-    assert P.transaction(pool, fn(conn) ->
-      opts2 = [log: fn(_) -> raise "logging oops" end]
-      stream = P.stream(conn, %Q{}, [:param], opts2)
-      assert capture_log(fn() ->
-        assert Enum.to_list(stream) == [%R{}]
-      end) =~ "logging oops"
-      :hi
-    end) == {:ok, :hi}
+    assert P.transaction(pool, fn conn ->
+             opts2 = [log: fn _ -> raise "logging oops" end]
+             stream = P.stream(conn, %Q{}, [:param], opts2)
+
+             assert capture_log(fn ->
+                      assert Enum.to_list(stream) == [%R{}]
+                    end) =~ "logging oops"
+
+             :hi
+           end) == {:ok, :hi}
 
     assert [
-      connect: [_],
-      handle_begin: [_, :state],
-      handle_declare: [%Q{}, [:param], _, :new_state],
-      handle_fetch: [%Q{}, %C{}, _, :newer_state],
-      handle_deallocate: [%Q{}, %C{}, _, :newest_state],
-      handle_commit: [_, :state2]
-      ] = A.record(agent)
+             connect: [_],
+             handle_begin: [_, :state],
+             handle_declare: [%Q{}, [:param], _, :new_state],
+             handle_fetch: [%Q{}, %C{}, _, :newer_state],
+             handle_deallocate: [%Q{}, %C{}, _, :newest_state],
+             handle_commit: [_, :state2]
+           ] = A.record(agent)
   end
 
   test "stream first bad return raises and stops" do
     stack = [
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], {:hi, self()})
         Process.link(opts[:parent])
         {:ok, :state}
@@ -503,7 +541,8 @@ defmodule StreamTest do
       {:ok, %Q{}, %C{}, :newer_state},
       :oops,
       {:ok, :state2}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
@@ -512,30 +551,39 @@ defmodule StreamTest do
     assert_receive {:hi, conn}
 
     Process.flag(:trap_exit, true)
-    assert P.transaction(pool, fn(conn) ->
-      stream = P.stream(conn, %Q{}, [:param])
-      assert_raise DBConnection.ConnectionError, "bad return value: :oops",
-        fn() -> Enum.to_list(stream) end
-      :hi
-    end) == {:error, :rollback}
 
-    prefix = "client #{inspect self()} stopped: " <>
-      "** (DBConnection.ConnectionError) bad return value: :oops"
+    assert P.transaction(pool, fn conn ->
+             stream = P.stream(conn, %Q{}, [:param])
+
+             assert_raise DBConnection.ConnectionError, "bad return value: :oops", fn ->
+               Enum.to_list(stream)
+             end
+
+             :hi
+           end) == {:error, :rollback}
+
+    prefix =
+      "client #{inspect(self())} stopped: " <>
+        "** (DBConnection.ConnectionError) bad return value: :oops"
+
     len = byte_size(prefix)
+
     assert_receive {:EXIT, ^conn,
-      {%DBConnection.ConnectionError{message: <<^prefix::binary-size(len), _::binary>>},
-        [_|_]}}
+                    {%DBConnection.ConnectionError{
+                       message: <<^prefix::binary-size(len), _::binary>>
+                     }, [_ | _]}}
 
     assert [
-      {:connect, _},
-      {:handle_begin, [_, :state]},
-      {:handle_declare, [%Q{}, [:param], _, :new_state]},
-      {:handle_fetch, [%Q{}, %C{}, _, :newer_state]} | _] = A.record(agent)
+             {:connect, _},
+             {:handle_begin, [_, :state]},
+             {:handle_declare, [%Q{}, [:param], _, :new_state]},
+             {:handle_fetch, [%Q{}, %C{}, _, :newer_state]} | _
+           ] = A.record(agent)
   end
 
   test "stream deallocate raise raises and stops connection" do
     stack = [
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], {:hi, self()})
         Process.link(opts[:parent])
         {:ok, :state}
@@ -543,11 +591,12 @@ defmodule StreamTest do
       {:ok, :began, :new_state},
       {:ok, %Q{}, %C{}, :newer_state},
       {:cont, %R{}, :newest_state},
-      fn(_, _, _, _) ->
+      fn _, _, _, _ ->
         raise "oops"
       end,
       {:ok, :state2}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
@@ -556,23 +605,27 @@ defmodule StreamTest do
     assert_receive {:hi, conn}
 
     Process.flag(:trap_exit, true)
-    assert P.transaction(pool, fn(conn) ->
-      stream = P.stream(conn, %Q{}, [:param])
-      assert_raise RuntimeError, "oops", fn() -> Enum.take(stream, 1) end
-      :hi
-    end) == {:error, :rollback}
 
-    prefix = "client #{inspect self()} stopped: ** (RuntimeError) oops"
+    assert P.transaction(pool, fn conn ->
+             stream = P.stream(conn, %Q{}, [:param])
+             assert_raise RuntimeError, "oops", fn -> Enum.take(stream, 1) end
+             :hi
+           end) == {:error, :rollback}
+
+    prefix = "client #{inspect(self())} stopped: ** (RuntimeError) oops"
     len = byte_size(prefix)
+
     assert_receive {:EXIT, ^conn,
-      {%DBConnection.ConnectionError{message: <<^prefix::binary-size(len), _::binary>>},
-        [_|_]}}
+                    {%DBConnection.ConnectionError{
+                       message: <<^prefix::binary-size(len), _::binary>>
+                     }, [_ | _]}}
 
     assert [
-      {:connect, _},
-      {:handle_begin, [_, :state]},
-      {:handle_declare, [%Q{}, [:param], _, :new_state]},
-      {:handle_fetch, [%Q{}, %C{}, _, :newer_state]},
-      {:handle_deallocate, [%Q{}, %C{}, _, :newest_state]} | _] = A.record(agent)
+             {:connect, _},
+             {:handle_begin, [_, :state]},
+             {:handle_declare, [%Q{}, [:param], _, :new_state]},
+             {:handle_fetch, [%Q{}, %C{}, _, :newer_state]},
+             {:handle_deallocate, [%Q{}, %C{}, _, :newest_state]} | _
+           ] = A.record(agent)
   end
 end

--- a/integration_test/cases/transaction_execute_test.exs
+++ b/integration_test/cases/transaction_execute_test.exs
@@ -13,24 +13,26 @@ defmodule TransactionExecuteTest do
       {:ok, %Q{}, %R{}, :newer_state},
       {:ok, %Q{}, %R{}, :newest_state},
       {:ok, :committed, :newest_state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
-    assert P.transaction(pool, fn(conn) ->
-      assert P.execute(conn, %Q{}, [:param]) == {:ok, %Q{}, %R{}}
-      assert P.execute(conn, %Q{}, [:param], [key: :value]) == {:ok, %Q{}, %R{}}
-      :hi
-    end) == {:ok, :hi}
+
+    assert P.transaction(pool, fn conn ->
+             assert P.execute(conn, %Q{}, [:param]) == {:ok, %Q{}, %R{}}
+             assert P.execute(conn, %Q{}, [:param], key: :value) == {:ok, %Q{}, %R{}}
+             :hi
+           end) == {:ok, :hi}
 
     assert [
-      connect: [_],
-      handle_begin: [_, :state],
-      handle_execute: [%Q{}, [:param], _, :new_state],
-      handle_execute: [%Q{}, [:param],
-        [{:key, :value} | _], :newer_state],
-      handle_commit: [_, :newest_state]] = A.record(agent)
+             connect: [_],
+             handle_begin: [_, :state],
+             handle_execute: [%Q{}, [:param], _, :new_state],
+             handle_execute: [%Q{}, [:param], [{:key, :value} | _], :newer_state],
+             handle_commit: [_, :newest_state]
+           ] = A.record(agent)
   end
 
   test "execute logs result" do
@@ -39,17 +41,22 @@ defmodule TransactionExecuteTest do
       {:ok, :began, :new_state},
       {:ok, %Q{}, %R{}, :newer_state},
       {:ok, :committed, :newest_state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
     opts = [agent: agent, parent: parent]
     {:ok, pool} = P.start_link(opts)
 
-    log = fn(entry) ->
-      assert %DBConnection.LogEntry{call: :execute, query: %Q{},
-                                    params: [:param],
-                                    result: {:ok, %Q{}, %R{}}} = entry
+    log = fn entry ->
+      assert %DBConnection.LogEntry{
+               call: :execute,
+               query: %Q{},
+               params: [:param],
+               result: {:ok, %Q{}, %R{}}
+             } = entry
+
       assert is_nil(entry.pool_time)
       assert is_integer(entry.connection_time)
       assert entry.connection_time >= 0
@@ -57,114 +64,125 @@ defmodule TransactionExecuteTest do
       assert entry.decode_time >= 0
       send(parent, :logged)
     end
-    assert P.transaction(pool, fn(conn) ->
-      assert P.execute(conn, %Q{}, [:param], [log: log]) == {:ok, %Q{}, %R{}}
-      :hi
-    end) == {:ok, :hi}
+
+    assert P.transaction(pool, fn conn ->
+             assert P.execute(conn, %Q{}, [:param], log: log) == {:ok, %Q{}, %R{}}
+             :hi
+           end) == {:ok, :hi}
 
     assert_received :logged
+
     assert [
-      connect: [_],
-      handle_begin: [_, :state],
-      handle_execute: [%Q{}, [:param], _, :new_state],
-      handle_commit: [_, :newer_state]] = A.record(agent)
+             connect: [_],
+             handle_begin: [_, :state],
+             handle_execute: [%Q{}, [:param], _, :new_state],
+             handle_commit: [_, :newer_state]
+           ] = A.record(agent)
   end
 
   test "execute error returns error" do
     err = RuntimeError.exception("oops")
+
     stack = [
       {:ok, :state},
       {:ok, :began, :new_state},
       {:error, err, :newer_state},
       {:ok, :committed, :newest_state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
 
-    assert P.transaction(pool, fn(conn) ->
-      assert P.execute(conn, %Q{}, [:param]) == {:error, err}
-      :hi
-    end) == {:ok, :hi}
+    assert P.transaction(pool, fn conn ->
+             assert P.execute(conn, %Q{}, [:param]) == {:error, err}
+             :hi
+           end) == {:ok, :hi}
 
     assert [
-      connect: [_],
-      handle_begin: [_, :state],
-      handle_execute: [%Q{}, [:param], _, :new_state],
-      handle_commit: [_, :newer_state]] = A.record(agent)
+             connect: [_],
+             handle_begin: [_, :state],
+             handle_execute: [%Q{}, [:param], _, :new_state],
+             handle_commit: [_, :newer_state]
+           ] = A.record(agent)
   end
 
   test "execute! error raises error" do
     err = RuntimeError.exception("oops")
+
     stack = [
       {:ok, :state},
       {:ok, :began, :new_state},
       {:error, err, :newer_state},
       {:ok, %Q{}, %R{}, :newest_state},
       {:ok, :committed, :newest_state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
 
-    assert P.transaction(pool, fn(conn) ->
-      assert_raise RuntimeError, "oops",
-        fn() -> P.execute!(conn, %Q{}, [:param]) end
+    assert P.transaction(pool, fn conn ->
+             assert_raise RuntimeError, "oops", fn -> P.execute!(conn, %Q{}, [:param]) end
 
-      assert P.execute(conn, %Q{}, [:param]) == {:ok, %Q{}, %R{}}
-      :hi
-    end) == {:ok, :hi}
+             assert P.execute(conn, %Q{}, [:param]) == {:ok, %Q{}, %R{}}
+             :hi
+           end) == {:ok, :hi}
 
     assert [
-      connect: [_],
-      handle_begin: [_, :state],
-      handle_execute: [%Q{}, [:param], _, :new_state],
-      handle_execute: [%Q{}, [:param], _, :newer_state],
-      handle_commit: [_, :newest_state]] = A.record(agent)
+             connect: [_],
+             handle_begin: [_, :state],
+             handle_execute: [%Q{}, [:param], _, :new_state],
+             handle_execute: [%Q{}, [:param], _, :newer_state],
+             handle_commit: [_, :newest_state]
+           ] = A.record(agent)
   end
 
   test "execute disconnect returns error" do
     err = RuntimeError.exception("oops")
+
     stack = [
       {:ok, :state},
       {:ok, :began, :new_state},
       {:disconnect, err, :newer_state},
       :ok,
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], :reconnected)
         {:ok, :state}
       end
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
 
-    assert P.transaction(pool, fn(conn) ->
-      assert P.execute(conn, %Q{}, [:param]) == {:error, err}
+    assert P.transaction(pool, fn conn ->
+             assert P.execute(conn, %Q{}, [:param]) == {:error, err}
 
-      assert_raise DBConnection.ConnectionError,
-                   "connection is closed because of an error, disconnect or timeout",
-                   fn() -> P.execute!(conn, %Q{}, [:param]) end
+             assert_raise DBConnection.ConnectionError,
+                          "connection is closed because of an error, disconnect or timeout",
+                          fn -> P.execute!(conn, %Q{}, [:param]) end
 
-      :closed
-    end) == {:error, :rollback}
+             :closed
+           end) == {:error, :rollback}
 
     assert_receive :reconnected
 
     assert [
-      connect: [opts2],
-      handle_begin: [_, :state],
-      handle_execute: [%Q{}, [:param], _, :new_state],
-      disconnect: [^err, :newer_state],
-      connect: [opts2]] = A.record(agent)
+             connect: [opts2],
+             handle_begin: [_, :state],
+             handle_execute: [%Q{}, [:param], _, :new_state],
+             disconnect: [^err, :newer_state],
+             connect: [opts2]
+           ] = A.record(agent)
   end
 
   test "execute bad return raises DBConnection.ConnectionError and stops" do
     stack = [
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], {:hi, self()})
         Process.link(opts[:parent])
         {:ok, :state}
@@ -172,7 +190,8 @@ defmodule TransactionExecuteTest do
       {:ok, :began, :new_state},
       :oops,
       {:ok, :state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
@@ -181,44 +200,50 @@ defmodule TransactionExecuteTest do
 
     Process.flag(:trap_exit, true)
 
-    assert P.transaction(pool, fn(conn) ->
-      assert_raise DBConnection.ConnectionError,
-                   "bad return value: :oops",
-                   fn() -> P.execute(conn, %Q{}, [:param]) end
+    assert P.transaction(pool, fn conn ->
+             assert_raise DBConnection.ConnectionError,
+                          "bad return value: :oops",
+                          fn -> P.execute(conn, %Q{}, [:param]) end
 
-      assert_raise DBConnection.ConnectionError,
-                   "connection is closed because of an error, disconnect or timeout",
-                   fn() -> P.execute!(conn, %Q{}, [:param]) end
+             assert_raise DBConnection.ConnectionError,
+                          "connection is closed because of an error, disconnect or timeout",
+                          fn -> P.execute!(conn, %Q{}, [:param]) end
 
-      :closed
-    end) == {:error, :rollback}
+             :closed
+           end) == {:error, :rollback}
 
-    prefix = "client #{inspect self()} stopped: " <>
-      "** (DBConnection.ConnectionError) bad return value: :oops"
+    prefix =
+      "client #{inspect(self())} stopped: " <>
+        "** (DBConnection.ConnectionError) bad return value: :oops"
+
     len = byte_size(prefix)
+
     assert_receive {:EXIT, ^conn,
-      {%DBConnection.ConnectionError{message: <<^prefix::binary-size(len), _::binary>>},
-        [_|_]}}
+                    {%DBConnection.ConnectionError{
+                       message: <<^prefix::binary-size(len), _::binary>>
+                     }, [_ | _]}}
 
     assert [
-      {:connect, _},
-      {:handle_begin, [_, :state]},
-      {:handle_execute, [%Q{}, [:param], _, :new_state]} | _] = A.record(agent)
+             {:connect, _},
+             {:handle_begin, [_, :state]},
+             {:handle_execute, [%Q{}, [:param], _, :new_state]} | _
+           ] = A.record(agent)
   end
 
   test "execute raise raises and stops connection" do
     stack = [
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], {:hi, self()})
         Process.link(opts[:parent])
         {:ok, :state}
       end,
       {:ok, :began, :new_state},
-      fn(_, _, _, _) ->
+      fn _, _, _, _ ->
         raise "oops"
       end,
       {:ok, :state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
@@ -227,29 +252,31 @@ defmodule TransactionExecuteTest do
 
     Process.flag(:trap_exit, true)
 
-    assert P.transaction(pool, fn(conn) ->
-      assert_raise RuntimeError,
-                   "oops",
-                   fn() -> P.execute(conn, %Q{}, [:param]) end
+    assert P.transaction(pool, fn conn ->
+             assert_raise RuntimeError,
+                          "oops",
+                          fn -> P.execute(conn, %Q{}, [:param]) end
 
-      assert_raise DBConnection.ConnectionError,
-                   "connection is closed because of an error, disconnect or timeout",
-                   fn() -> P.execute!(conn, %Q{}, [:param]) end
+             assert_raise DBConnection.ConnectionError,
+                          "connection is closed because of an error, disconnect or timeout",
+                          fn -> P.execute!(conn, %Q{}, [:param]) end
 
-      :closed
-    end) == {:error, :rollback}
+             :closed
+           end) == {:error, :rollback}
 
-
-    prefix = "client #{inspect self()} stopped: ** (RuntimeError) oops"
+    prefix = "client #{inspect(self())} stopped: ** (RuntimeError) oops"
     len = byte_size(prefix)
+
     assert_receive {:EXIT, ^conn,
-      {%DBConnection.ConnectionError{message: <<^prefix::binary-size(len), _::binary>>},
-       [_|_]}}
+                    {%DBConnection.ConnectionError{
+                       message: <<^prefix::binary-size(len), _::binary>>
+                     }, [_ | _]}}
 
     assert [
-      {:connect, _},
-      {:handle_begin, [_, :state]},
-      {:handle_execute, [%Q{}, [:param], _, :new_state]}| _] = A.record(agent)
+             {:connect, _},
+             {:handle_begin, [_, :state]},
+             {:handle_execute, [%Q{}, [:param], _, :new_state]} | _
+           ] = A.record(agent)
   end
 
   test "execute raises after inner transaction rollback" do
@@ -257,42 +284,45 @@ defmodule TransactionExecuteTest do
       {:ok, :state},
       {:ok, :began, :new_state},
       :ok,
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], :reconnected)
         {:ok, :state}
       end
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
 
-    assert P.transaction(pool, fn(conn) ->
-      assert P.transaction(conn, fn(conn2) ->
-        P.rollback(conn2, :oops)
-      end) == {:error, :oops}
+    assert P.transaction(pool, fn conn ->
+             assert P.transaction(conn, fn conn2 ->
+                      P.rollback(conn2, :oops)
+                    end) == {:error, :oops}
 
-      assert_raise DBConnection.ConnectionError,
-        "transaction rolling back",
-        fn() -> P.execute!(conn, %Q{}, [:param]) end
-    end) == {:error, :rollback}
+             assert_raise DBConnection.ConnectionError,
+                          "transaction rolling back",
+                          fn -> P.execute!(conn, %Q{}, [:param]) end
+           end) == {:error, :rollback}
 
     assert_receive :reconnected
 
     assert [
-      connect: [_],
-      handle_begin: [ _, :state],
-      disconnect: _,
-      connect: _] = A.record(agent)
+             connect: [_],
+             handle_begin: [_, :state],
+             disconnect: _,
+             connect: _
+           ] = A.record(agent)
   end
 
   test "transaction logs rollback if closed" do
-   stack = [
+    stack = [
       {:ok, :state},
       {:ok, :began, :new_state},
       :oops,
       {:ok, :state2}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
@@ -302,18 +332,24 @@ defmodule TransactionExecuteTest do
 
     log = &send(parent, &1)
 
-    P.transaction(pool, fn(conn) ->
-      assert_received %DBConnection.LogEntry{call: :begin, query: :begin}
-      assert_raise DBConnection.ConnectionError,
-        fn() -> P.execute(conn, %Q{}, [:param]) end
-    end, [log: log])
+    P.transaction(
+      pool,
+      fn conn ->
+        assert_received %DBConnection.LogEntry{call: :begin, query: :begin}
+
+        assert_raise DBConnection.ConnectionError,
+                     fn -> P.execute(conn, %Q{}, [:param]) end
+      end,
+      log: log
+    )
 
     assert_received %DBConnection.LogEntry{call: :rollback, query: :rollback}
 
     assert [
-      {:connect, [_]},
-      {:handle_begin, [_, :state]},
-      {:handle_execute, [%Q{}, [:param], _, :new_state]} |
-      _] = A.record(agent)
+             {:connect, [_]},
+             {:handle_begin, [_, :state]},
+             {:handle_execute, [%Q{}, [:param], _, :new_state]}
+             | _
+           ] = A.record(agent)
   end
 end

--- a/integration_test/cases/transaction_test.exs
+++ b/integration_test/cases/transaction_test.exs
@@ -11,28 +11,34 @@ defmodule TransactionTest do
       {:ok, :committed, :newer_state},
       {:ok, :began, :newest_state},
       {:ok, :committed, :newest_state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
 
-    assert P.transaction(pool, fn(conn) ->
-      assert %DBConnection{} = conn
-      :result
-    end) == {:ok, :result}
+    assert P.transaction(pool, fn conn ->
+             assert %DBConnection{} = conn
+             :result
+           end) == {:ok, :result}
 
-    assert P.transaction(pool, fn(conn) ->
-      assert %DBConnection{} = conn
-      :result
-    end, [key: :value]) == {:ok, :result}
+    assert P.transaction(
+             pool,
+             fn conn ->
+               assert %DBConnection{} = conn
+               :result
+             end,
+             key: :value
+           ) == {:ok, :result}
 
     assert [
-      connect: [_],
-      handle_begin: [ _, :state],
-      handle_commit: [_, :new_state],
-      handle_begin: [[{:key, :value} | _], :newer_state],
-      handle_commit: [[{:key, :value} | _], :newest_state]] = A.record(agent)
+             connect: [_],
+             handle_begin: [_, :state],
+             handle_commit: [_, :new_state],
+             handle_begin: [[{:key, :value} | _], :newer_state],
+             handle_commit: [[{:key, :value} | _], :newest_state]
+           ] = A.record(agent)
   end
 
   test "transaction logs begin/commit/rollback" do
@@ -42,7 +48,8 @@ defmodule TransactionTest do
       {:ok, :committed, :newer_state},
       {:ok, :began, :newest_state},
       {:ok, :rolledback, :newest_state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
@@ -51,17 +58,21 @@ defmodule TransactionTest do
 
     log = &send(parent, &1)
 
-    assert P.transaction(pool, fn(_) ->
-      assert_received %DBConnection.LogEntry{call: :begin} = entry
-      assert %{query: :begin, params: nil, result: {:ok, _, :began}} = entry
-      assert is_integer(entry.pool_time)
-      assert entry.pool_time >= 0
-      assert is_integer(entry.connection_time)
-      assert entry.connection_time >= 0
-      assert is_nil(entry.decode_time)
+    assert P.transaction(
+             pool,
+             fn _ ->
+               assert_received %DBConnection.LogEntry{call: :begin} = entry
+               assert %{query: :begin, params: nil, result: {:ok, _, :began}} = entry
+               assert is_integer(entry.pool_time)
+               assert entry.pool_time >= 0
+               assert is_integer(entry.connection_time)
+               assert entry.connection_time >= 0
+               assert is_nil(entry.decode_time)
 
-      :result
-    end, [log: log]) == {:ok, :result}
+               :result
+             end,
+             log: log
+           ) == {:ok, :result}
 
     assert_received %DBConnection.LogEntry{call: :commit} = entry
     assert %{query: :commit, params: nil, result: {:ok, :committed}} = entry
@@ -70,10 +81,14 @@ defmodule TransactionTest do
     assert entry.connection_time >= 0
     assert is_nil(entry.decode_time)
 
-    assert P.transaction(pool, fn(conn) ->
-      assert_received %DBConnection.LogEntry{call: :begin}
-      P.rollback(conn, :result)
-    end, [log: log]) == {:error, :result}
+    assert P.transaction(
+             pool,
+             fn conn ->
+               assert_received %DBConnection.LogEntry{call: :begin}
+               P.rollback(conn, :result)
+             end,
+             log: log
+           ) == {:error, :result}
 
     assert_received %DBConnection.LogEntry{call: :rollback} = entry
     assert %{query: :rollback, params: nil, result: {:ok, :rolledback}} = entry
@@ -83,11 +98,12 @@ defmodule TransactionTest do
     assert is_nil(entry.decode_time)
 
     assert [
-      connect: [_],
-      handle_begin: [ _, :state],
-      handle_commit: [_, :new_state],
-      handle_begin: [_, :newer_state],
-      handle_rollback: [_, :newest_state]] = A.record(agent)
+             connect: [_],
+             handle_begin: [_, :state],
+             handle_commit: [_, :new_state],
+             handle_begin: [_, :newer_state],
+             handle_rollback: [_, :newest_state]
+           ] = A.record(agent)
   end
 
   test "transaction rollback returns error" do
@@ -97,24 +113,26 @@ defmodule TransactionTest do
       {:ok, :rolledback, :newer_state},
       {:ok, :began, :newest_state},
       {:ok, :rolledback, :newest_state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
 
-    assert P.transaction(pool, fn(conn) ->
-      P.rollback(conn, :oops)
-    end) == {:error, :oops}
+    assert P.transaction(pool, fn conn ->
+             P.rollback(conn, :oops)
+           end) == {:error, :oops}
 
-    assert P.transaction(pool, fn(_) -> :result end) == {:ok, :result}
+    assert P.transaction(pool, fn _ -> :result end) == {:ok, :result}
 
     assert [
-      connect: [_],
-      handle_begin: [ _, :state],
-      handle_rollback: [_, :new_state],
-      handle_begin: [_, :newer_state],
-      handle_commit: [_, :newest_state]] = A.record(agent)
+             connect: [_],
+             handle_begin: [_, :state],
+             handle_rollback: [_, :new_state],
+             handle_begin: [_, :newer_state],
+             handle_commit: [_, :newest_state]
+           ] = A.record(agent)
   end
 
   test "inner transaction rollback returns error on other transactions" do
@@ -124,28 +142,30 @@ defmodule TransactionTest do
       {:ok, :rolledback, :newer_state},
       {:ok, :began, :newest_state},
       {:ok, :comittted, :newest_state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
 
-    assert P.transaction(pool, fn(conn) ->
-      assert P.transaction(conn, fn(conn2) ->
-        P.rollback(conn2, :oops)
-      end) == {:error, :oops}
+    assert P.transaction(pool, fn conn ->
+             assert P.transaction(conn, fn conn2 ->
+                      P.rollback(conn2, :oops)
+                    end) == {:error, :oops}
 
-      assert P.transaction(conn, fn(_) -> nil end) == {:error, :rollback}
-    end) == {:error, :rollback}
+             assert P.transaction(conn, fn _ -> nil end) == {:error, :rollback}
+           end) == {:error, :rollback}
 
-    assert P.transaction(pool, fn(_) -> :result end) == {:ok, :result}
+    assert P.transaction(pool, fn _ -> :result end) == {:ok, :result}
 
     assert [
-      connect: [_],
-      handle_begin: [ _, :state],
-      handle_rollback: [_, :new_state],
-      handle_begin: [_, :newer_state],
-      handle_commit: [_, :newest_state]] = A.record(agent)
+             connect: [_],
+             handle_begin: [_, :state],
+             handle_rollback: [_, :new_state],
+             handle_begin: [_, :newer_state],
+             handle_commit: [_, :newest_state]
+           ] = A.record(agent)
   end
 
   test "outer transaction rolls back after inner rollback" do
@@ -155,28 +175,30 @@ defmodule TransactionTest do
       {:ok, :rolledback, :newer_state},
       {:ok, :began, :newest_state},
       {:ok, :committed, :newest_state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
 
-    assert P.transaction(pool, fn(conn) ->
-      assert P.transaction(conn, fn(conn2) ->
-        P.rollback(conn2, :oops)
-      end) == {:error, :oops}
+    assert P.transaction(pool, fn conn ->
+             assert P.transaction(conn, fn conn2 ->
+                      P.rollback(conn2, :oops)
+                    end) == {:error, :oops}
 
-      P.rollback(conn, :oops2)
-    end) == {:error, :oops2}
+             P.rollback(conn, :oops2)
+           end) == {:error, :oops2}
 
-    assert P.transaction(pool, fn(_) -> :result end) == {:ok, :result}
+    assert P.transaction(pool, fn _ -> :result end) == {:ok, :result}
 
     assert [
-      connect: [_],
-      handle_begin: [ _, :state],
-      handle_rollback: [_, :new_state],
-      handle_begin: [_, :newer_state],
-      handle_commit: [_, :newest_state]] = A.record(agent)
+             connect: [_],
+             handle_begin: [_, :state],
+             handle_rollback: [_, :new_state],
+             handle_begin: [_, :newer_state],
+             handle_commit: [_, :newest_state]
+           ] = A.record(agent)
   end
 
   test "inner transaction raise returns error on other transactions" do
@@ -186,27 +208,30 @@ defmodule TransactionTest do
       {:ok, :rolledback, :newer_state},
       {:ok, :began, :newest_state},
       {:ok, :committed, :newest_state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
 
-    assert P.transaction(pool, fn(conn) ->
-      assert_raise RuntimeError, "oops",
-       fn() -> P.transaction(conn, fn(_) -> raise "oops" end) end
+    assert P.transaction(pool, fn conn ->
+             assert_raise RuntimeError, "oops", fn ->
+               P.transaction(conn, fn _ -> raise "oops" end)
+             end
 
-      assert P.transaction(conn, fn(_) -> nil end) ==  {:error, :rollback}
-    end) == {:error, :rollback}
+             assert P.transaction(conn, fn _ -> nil end) == {:error, :rollback}
+           end) == {:error, :rollback}
 
-    assert P.transaction(pool, fn(_) -> :result end) == {:ok, :result}
+    assert P.transaction(pool, fn _ -> :result end) == {:ok, :result}
 
     assert [
-      connect: [_],
-      handle_begin: [ _, :state],
-      handle_rollback: [_, :new_state],
-      handle_begin: [_, :newer_state],
-      handle_commit: [_, :newest_state]] = A.record(agent)
+             connect: [_],
+             handle_begin: [_, :state],
+             handle_rollback: [_, :new_state],
+             handle_begin: [_, :newer_state],
+             handle_commit: [_, :newest_state]
+           ] = A.record(agent)
   end
 
   test "transaction and transaction returns result" do
@@ -214,25 +239,28 @@ defmodule TransactionTest do
       {:ok, :state},
       {:ok, :began, :new_state},
       {:ok, :committed, :newer_state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
 
-    assert P.transaction(pool, fn(conn) ->
-      assert P.transaction(conn, fn(conn2) ->
-        assert %DBConnection{} = conn2
-        assert conn == conn2
-        :result
-      end) == {:ok, :result}
-      :result
-    end) == {:ok, :result}
+    assert P.transaction(pool, fn conn ->
+             assert P.transaction(conn, fn conn2 ->
+                      assert %DBConnection{} = conn2
+                      assert conn == conn2
+                      :result
+                    end) == {:ok, :result}
+
+             :result
+           end) == {:ok, :result}
 
     assert [
-      connect: [_],
-      handle_begin: [ _, :state],
-      handle_commit: [_, :new_state]] = A.record(agent)
+             connect: [_],
+             handle_begin: [_, :state],
+             handle_commit: [_, :new_state]
+           ] = A.record(agent)
   end
 
   test "transaction and run returns result" do
@@ -240,58 +268,67 @@ defmodule TransactionTest do
       {:ok, :state},
       {:ok, :began, :new_state},
       {:ok, :committed, :newer_state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
 
-    assert P.transaction(pool, fn(conn) ->
-      assert P.run(conn, fn(conn2) ->
-        assert %DBConnection{} = conn2
-        assert conn == conn2
-        :result
-      end) == :result
-      :result
-    end) == {:ok, :result}
+    assert P.transaction(pool, fn conn ->
+             assert P.run(conn, fn conn2 ->
+                      assert %DBConnection{} = conn2
+                      assert conn == conn2
+                      :result
+                    end) == :result
+
+             :result
+           end) == {:ok, :result}
 
     assert [
-      connect: [_],
-      handle_begin: [ _, :state],
-      handle_commit: [_, :new_state]] = A.record(agent)
+             connect: [_],
+             handle_begin: [_, :state],
+             handle_commit: [_, :new_state]
+           ] = A.record(agent)
   end
 
   test "transaction begin error raises error" do
     err = RuntimeError.exception("oops")
+
     stack = [
       {:ok, :state},
       {:error, err, :new_state},
       {:ok, :began, :newer_state},
       {:ok, :committed, :newest_state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
 
-    assert_raise RuntimeError, "oops",
-      fn() -> P.transaction(pool, fn(_) -> flunk("transaction ran") end) end
+    assert_raise RuntimeError, "oops", fn ->
+      P.transaction(pool, fn _ -> flunk("transaction ran") end)
+    end
 
-    assert P.transaction(pool, fn(_) -> :result end) == {:ok, :result}
+    assert P.transaction(pool, fn _ -> :result end) == {:ok, :result}
 
     assert [
-      connect: [_],
-      handle_begin: [ _, :state],
-      handle_begin: [_, :new_state],
-      handle_commit: [_, :newer_state]] = A.record(agent)
+             connect: [_],
+             handle_begin: [_, :state],
+             handle_begin: [_, :new_state],
+             handle_commit: [_, :newer_state]
+           ] = A.record(agent)
   end
 
   test "transaction logs begin error" do
     err = RuntimeError.exception("oops")
+
     stack = [
       {:ok, :state},
       {:error, err, :new_state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
@@ -299,10 +336,10 @@ defmodule TransactionTest do
     {:ok, pool} = P.start_link(opts)
 
     log = &send(parent, &1)
-    assert_raise RuntimeError, "oops",
-      fn() ->
-        P.transaction(pool, fn(_) -> flunk("transaction ran") end, [log: log])
-      end
+
+    assert_raise RuntimeError, "oops", fn ->
+      P.transaction(pool, fn _ -> flunk("transaction ran") end, log: log)
+    end
 
     assert_received %DBConnection.LogEntry{call: :begin} = entry
     assert %{query: :begin, params: nil, result: {:error, ^err}} = entry
@@ -313,21 +350,23 @@ defmodule TransactionTest do
     assert is_nil(entry.decode_time)
 
     assert [
-      connect: [_],
-      handle_begin: [ _, :state]] = A.record(agent)
+             connect: [_],
+             handle_begin: [_, :state]
+           ] = A.record(agent)
   end
 
   test "transaction logs begin raise" do
     stack = [
-      fn(opts) ->
+      fn opts ->
         Process.link(opts[:parent])
         {:ok, :state}
       end,
-      fn(_, _) ->
+      fn _, _ ->
         raise "oops"
       end,
       {:ok, :state2}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
@@ -336,64 +375,74 @@ defmodule TransactionTest do
     {:ok, pool} = P.start_link(opts)
 
     log = &send(parent, &1)
-    assert_raise RuntimeError, "oops",
-      fn() ->
-        P.transaction(pool, fn(_) -> flunk("transaction ran") end, [log: log])
-      end
+
+    assert_raise RuntimeError, "oops", fn ->
+      P.transaction(pool, fn _ -> flunk("transaction ran") end, log: log)
+    end
 
     assert_received %DBConnection.LogEntry{call: :begin} = entry
     assert %{query: :begin, params: nil, result: {:error, err}} = entry
-    assert %DBConnection.ConnectionError{message: "an exception was raised: ** (RuntimeError) oops" <> _} = err
+
+    assert %DBConnection.ConnectionError{
+             message: "an exception was raised: ** (RuntimeError) oops" <> _
+           } = err
+
     assert is_integer(entry.pool_time)
     assert entry.pool_time >= 0
     assert is_integer(entry.connection_time)
     assert entry.connection_time >= 0
     assert is_nil(entry.decode_time)
-    assert_receive {:EXIT, _, {%DBConnection.ConnectionError{}, [_|_]}}
+    assert_receive {:EXIT, _, {%DBConnection.ConnectionError{}, [_ | _]}}
 
     assert [
-      {:connect, [_]},
-      {:handle_begin, [ _, :state]} | _] = A.record(agent)
+             {:connect, [_]},
+             {:handle_begin, [_, :state]} | _
+           ] = A.record(agent)
   end
 
   test "transaction begin disconnect raises error" do
     err = RuntimeError.exception("oops")
+
     stack = [
       {:ok, :state},
       {:disconnect, err, :new_state},
       :ok,
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], :reconnected)
         {:ok, :newest_state}
       end
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
 
-    assert_raise RuntimeError, "oops",
-      fn() -> P.transaction(pool, fn(_) -> flunk("transaction ran") end) end
+    assert_raise RuntimeError, "oops", fn ->
+      P.transaction(pool, fn _ -> flunk("transaction ran") end)
+    end
 
     assert_receive :reconnected
 
     assert [
-      connect: [_],
-      handle_begin: [_, :state],
-      disconnect: [_, :new_state],
-      connect: [_]] = A.record(agent)
+             connect: [_],
+             handle_begin: [_, :state],
+             disconnect: [_, :new_state],
+             connect: [_]
+           ] = A.record(agent)
   end
 
   test "transaction begin bad return raises and stops connection" do
     stack = [
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], {:hi, self()})
         Process.link(opts[:parent])
         {:ok, :state}
       end,
       :oops,
       {:ok, :state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
@@ -401,33 +450,41 @@ defmodule TransactionTest do
     assert_receive {:hi, conn}
 
     Process.flag(:trap_exit, true)
-    assert_raise DBConnection.ConnectionError, "bad return value: :oops",
-      fn() -> P.transaction(pool, fn(_) -> flunk("transaction ran") end) end
 
-    prefix = "client #{inspect self()} stopped: " <>
-      "** (DBConnection.ConnectionError) bad return value: :oops"
+    assert_raise DBConnection.ConnectionError, "bad return value: :oops", fn ->
+      P.transaction(pool, fn _ -> flunk("transaction ran") end)
+    end
+
+    prefix =
+      "client #{inspect(self())} stopped: " <>
+        "** (DBConnection.ConnectionError) bad return value: :oops"
+
     len = byte_size(prefix)
+
     assert_receive {:EXIT, ^conn,
-      {%DBConnection.ConnectionError{message: <<^prefix::binary-size(len), _::binary>>},
-        [_|_]}}
+                    {%DBConnection.ConnectionError{
+                       message: <<^prefix::binary-size(len), _::binary>>
+                     }, [_ | _]}}
 
     assert [
-      {:connect, _},
-      {:handle_begin, [_, :state]}| _] = A.record(agent)
+             {:connect, _},
+             {:handle_begin, [_, :state]} | _
+           ] = A.record(agent)
   end
 
   test "transaction begin raise raises and stops connection" do
     stack = [
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], {:hi, self()})
         Process.link(opts[:parent])
         {:ok, :state}
       end,
-      fn(_, _) ->
+      fn _, _ ->
         raise "oops"
       end,
       {:ok, :state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
@@ -435,54 +492,63 @@ defmodule TransactionTest do
     assert_receive {:hi, conn}
 
     Process.flag(:trap_exit, true)
-    assert_raise RuntimeError, "oops",
-      fn() -> P.transaction(pool, fn(_) -> flunk("transaction ran") end) end
 
-    prefix = "client #{inspect self()} stopped: ** (RuntimeError) oops"
+    assert_raise RuntimeError, "oops", fn ->
+      P.transaction(pool, fn _ -> flunk("transaction ran") end)
+    end
+
+    prefix = "client #{inspect(self())} stopped: ** (RuntimeError) oops"
     len = byte_size(prefix)
+
     assert_receive {:EXIT, ^conn,
-      {%DBConnection.ConnectionError{message: <<^prefix::binary-size(len), _::binary>>},
-       [_|_]}}
+                    {%DBConnection.ConnectionError{
+                       message: <<^prefix::binary-size(len), _::binary>>
+                     }, [_ | _]}}
 
     assert [
-      {:connect, _},
-      {:handle_begin, [_, :state]} | _] = A.record(agent)
+             {:connect, _},
+             {:handle_begin, [_, :state]} | _
+           ] = A.record(agent)
   end
 
   test "transaction commit error raises error" do
     err = RuntimeError.exception("oops")
+
     stack = [
       {:ok, :state},
       {:ok, :began, :new_state},
       {:error, err, :newer_state},
       {:ok, :began, :newest_state},
       {:ok, :committed, :newest_state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
 
-    assert_raise RuntimeError, "oops",
-      fn() -> P.transaction(pool, fn(_) -> :ok end) end
+    assert_raise RuntimeError, "oops", fn -> P.transaction(pool, fn _ -> :ok end) end
 
-    assert P.transaction(pool, fn(_) -> :result end) == {:ok, :result}
+    assert P.transaction(pool, fn _ -> :result end) == {:ok, :result}
 
     assert [
-      connect: [_],
-      handle_begin: [_, :state],
-      handle_commit: [_, :new_state],
-      handle_begin: [_, :newer_state],
-      handle_commit: [_, :newest_state]] = A.record(agent)
+             connect: [_],
+             handle_begin: [_, :state],
+             handle_commit: [_, :new_state],
+             handle_begin: [_, :newer_state],
+             handle_commit: [_, :newest_state]
+           ] = A.record(agent)
   end
 
   test "transaction logs commit error" do
     err = RuntimeError.exception("oops")
+
     stack = [
       {:ok, :state},
       {:ok, :began, :new_state},
-      {:error, err, :newer_state},
-      ]
+      {:error, err, :newer_state}
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
@@ -491,12 +557,15 @@ defmodule TransactionTest do
 
     log = &send(parent, &1)
 
-    assert_raise RuntimeError, "oops",
-      fn() ->
-        P.transaction(pool, fn(_) ->
+    assert_raise RuntimeError, "oops", fn ->
+      P.transaction(
+        pool,
+        fn _ ->
           assert_received %DBConnection.LogEntry{call: :begin}
-        end, [log: log])
-      end
+        end,
+        log: log
+      )
+    end
 
     assert_received %DBConnection.LogEntry{call: :commit} = entry
     assert %{query: :commit, params: nil, result: {:error, ^err}} = entry
@@ -506,44 +575,47 @@ defmodule TransactionTest do
     assert is_nil(entry.decode_time)
 
     assert [
-      connect: [_],
-      handle_begin: [_, :state],
-      handle_commit: [_, :new_state]] = A.record(agent)
+             connect: [_],
+             handle_begin: [_, :state],
+             handle_commit: [_, :new_state]
+           ] = A.record(agent)
   end
 
   test "transaction commit disconnect raises error" do
     err = RuntimeError.exception("oops")
+
     stack = [
       {:ok, :state},
       {:ok, :began, :new_state},
       {:disconnect, err, :newer_state},
       :ok,
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], :reconnected)
         {:ok, :newest_state}
       end
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
 
-    assert_raise RuntimeError, "oops",
-      fn() -> P.transaction(pool, fn(_) -> :result end) end
+    assert_raise RuntimeError, "oops", fn -> P.transaction(pool, fn _ -> :result end) end
 
     assert_receive :reconnected
 
     assert [
-      connect: [_],
-      handle_begin: [_, :state],
-      handle_commit: [_, :new_state],
-      disconnect: [_, :newer_state],
-      connect: [_]] = A.record(agent)
+             connect: [_],
+             handle_begin: [_, :state],
+             handle_commit: [_, :new_state],
+             disconnect: [_, :newer_state],
+             connect: [_]
+           ] = A.record(agent)
   end
 
   test "transaction commit bad return raises and stops connection" do
     stack = [
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], {:hi, self()})
         Process.link(opts[:parent])
         {:ok, :state}
@@ -551,7 +623,8 @@ defmodule TransactionTest do
       {:ok, :began, :new_state},
       :oops,
       {:ok, :state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
@@ -559,35 +632,43 @@ defmodule TransactionTest do
     assert_receive {:hi, conn}
 
     Process.flag(:trap_exit, true)
-    assert_raise DBConnection.ConnectionError, "bad return value: :oops",
-      fn() -> P.transaction(pool, fn(_) -> :result end) end
 
-    prefix = "client #{inspect self()} stopped: " <>
-      "** (DBConnection.ConnectionError) bad return value: :oops"
+    assert_raise DBConnection.ConnectionError, "bad return value: :oops", fn ->
+      P.transaction(pool, fn _ -> :result end)
+    end
+
+    prefix =
+      "client #{inspect(self())} stopped: " <>
+        "** (DBConnection.ConnectionError) bad return value: :oops"
+
     len = byte_size(prefix)
+
     assert_receive {:EXIT, ^conn,
-      {%DBConnection.ConnectionError{message: <<^prefix::binary-size(len), _::binary>>},
-        [_|_]}}
+                    {%DBConnection.ConnectionError{
+                       message: <<^prefix::binary-size(len), _::binary>>
+                     }, [_ | _]}}
 
     assert [
-      {:connect, _},
-      {:handle_begin, [_, :state]},
-      {:handle_commit, [_, :new_state]} | _] = A.record(agent)
+             {:connect, _},
+             {:handle_begin, [_, :state]},
+             {:handle_commit, [_, :new_state]} | _
+           ] = A.record(agent)
   end
 
   test "transaction commit raise raises and stops connection" do
     stack = [
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], {:hi, self()})
         Process.link(opts[:parent])
         {:ok, :state}
       end,
       {:ok, :began, :new_state},
-      fn(_, _) ->
+      fn _, _ ->
         raise "oops"
       end,
       {:ok, :state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
@@ -595,33 +676,36 @@ defmodule TransactionTest do
     assert_receive {:hi, conn}
 
     Process.flag(:trap_exit, true)
-    assert_raise RuntimeError, "oops",
-      fn() -> P.transaction(pool, fn(_) -> :result end) end
+    assert_raise RuntimeError, "oops", fn -> P.transaction(pool, fn _ -> :result end) end
 
-    prefix = "client #{inspect self()} stopped: ** (RuntimeError) oops"
+    prefix = "client #{inspect(self())} stopped: ** (RuntimeError) oops"
     len = byte_size(prefix)
+
     assert_receive {:EXIT, ^conn,
-      {%DBConnection.ConnectionError{message: <<^prefix::binary-size(len), _::binary>>},
-       [_|_]}}
+                    {%DBConnection.ConnectionError{
+                       message: <<^prefix::binary-size(len), _::binary>>
+                     }, [_ | _]}}
 
     assert [
-      {:connect, _},
-      {:handle_begin, [_, :state]},
-      {:handle_commit, [_, :new_state]} | _] = A.record(agent)
+             {:connect, _},
+             {:handle_begin, [_, :state]},
+             {:handle_commit, [_, :new_state]} | _
+           ] = A.record(agent)
   end
 
   test "transaction logs commit raise" do
     stack = [
-      fn(opts) ->
+      fn opts ->
         Process.link(opts[:parent])
         {:ok, :state}
       end,
       {:ok, :began, :new_state},
-      fn(_, _) ->
+      fn _, _ ->
         raise "oops"
       end,
       {:ok, :state2}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
@@ -630,88 +714,97 @@ defmodule TransactionTest do
     {:ok, pool} = P.start_link(opts)
 
     log = &send(parent, &1)
-    assert_raise RuntimeError, "oops",
-      fn() ->
-        P.transaction(pool, fn(_) -> :ok end, [log: log])
-      end
+
+    assert_raise RuntimeError, "oops", fn ->
+      P.transaction(pool, fn _ -> :ok end, log: log)
+    end
 
     assert_received %DBConnection.LogEntry{call: :begin} = entry
     assert %{query: :begin, params: nil, result: {:ok, _, :began}} = entry
 
     assert_received %DBConnection.LogEntry{call: :commit} = entry
     assert %{query: :commit, params: nil, result: {:error, err}} = entry
-    assert %DBConnection.ConnectionError{message: "an exception was raised: ** (RuntimeError) oops" <> _} = err
+
+    assert %DBConnection.ConnectionError{
+             message: "an exception was raised: ** (RuntimeError) oops" <> _
+           } = err
+
     assert is_nil(entry.pool_time)
     assert is_integer(entry.connection_time)
     assert entry.connection_time >= 0
     assert is_nil(entry.decode_time)
-    assert_receive {:EXIT, _, {%DBConnection.ConnectionError{}, [_|_]}}
+    assert_receive {:EXIT, _, {%DBConnection.ConnectionError{}, [_ | _]}}
 
     assert [
-      {:connect, [_]},
-      {:handle_begin, [_, :state]},
-      {:handle_commit, [_, :new_state]} | _] = A.record(agent)
+             {:connect, [_]},
+             {:handle_begin, [_, :state]},
+             {:handle_commit, [_, :new_state]} | _
+           ] = A.record(agent)
   end
 
   test "transaction rollback error raises error" do
     err = RuntimeError.exception("oops")
+
     stack = [
       {:ok, :state},
       {:ok, :began, :new_state},
       {:error, err, :newer_state},
       {:ok, :began, :newest_state},
       {:ok, :rolledback, :newest_state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
 
-    assert_raise RuntimeError, "oops",
-      fn() -> P.transaction(pool, &P.rollback(&1, :oops)) end
+    assert_raise RuntimeError, "oops", fn -> P.transaction(pool, &P.rollback(&1, :oops)) end
 
-    assert P.transaction(pool, fn(_) -> :result end) == {:ok, :result}
+    assert P.transaction(pool, fn _ -> :result end) == {:ok, :result}
 
     assert [
-      connect: [_],
-      handle_begin: [_, :state],
-      handle_rollback: [_, :new_state],
-      handle_begin: [_, :newer_state],
-      handle_commit: [_, :newest_state]] = A.record(agent)
+             connect: [_],
+             handle_begin: [_, :state],
+             handle_rollback: [_, :new_state],
+             handle_begin: [_, :newer_state],
+             handle_commit: [_, :newest_state]
+           ] = A.record(agent)
   end
 
   test "transaction fun raise rolls back and re-raises" do
-   stack = [
+    stack = [
       {:ok, :state},
       {:ok, :began, :new_state},
-      {:ok, :rolledback, :newer_state},
-      ]
+      {:ok, :rolledback, :newer_state}
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
 
-    assert_raise RuntimeError, "oops",
-      fn() -> P.transaction(pool, fn(_) -> raise "oops"end) end
+    assert_raise RuntimeError, "oops", fn -> P.transaction(pool, fn _ -> raise "oops" end) end
 
     assert [
-      connect: [_],
-      handle_begin: [_, :state],
-      handle_rollback: [_, :new_state]] = A.record(agent)
+             connect: [_],
+             handle_begin: [_, :state],
+             handle_rollback: [_, :new_state]
+           ] = A.record(agent)
   end
 
   test "transaction logs rollback raise" do
     stack = [
-      fn(opts) ->
+      fn opts ->
         Process.link(opts[:parent])
         {:ok, :state}
       end,
       {:ok, :began, :new_state},
-      fn(_, _) ->
+      fn _, _ ->
         raise "oops"
       end,
       {:ok, :state2}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
@@ -720,35 +813,41 @@ defmodule TransactionTest do
     {:ok, pool} = P.start_link(opts)
 
     log = &send(parent, &1)
-    assert_raise RuntimeError, "oops",
-      fn() ->
-        P.transaction(pool, &P.rollback(&1, :oops), [log: log])
-      end
+
+    assert_raise RuntimeError, "oops", fn ->
+      P.transaction(pool, &P.rollback(&1, :oops), log: log)
+    end
 
     assert_received %DBConnection.LogEntry{call: :begin} = entry
     assert %{query: :begin, params: nil, result: {:ok, _, :began}} = entry
 
     assert_received %DBConnection.LogEntry{call: :rollback} = entry
     assert %{query: :rollback, params: nil, result: {:error, err}} = entry
-    assert %DBConnection.ConnectionError{message: "an exception was raised: ** (RuntimeError) oops" <> _} = err
+
+    assert %DBConnection.ConnectionError{
+             message: "an exception was raised: ** (RuntimeError) oops" <> _
+           } = err
+
     assert is_nil(entry.pool_time)
     assert is_integer(entry.connection_time)
     assert entry.connection_time >= 0
     assert is_nil(entry.decode_time)
-    assert_receive {:EXIT, _, {%DBConnection.ConnectionError{}, [_|_]}}
+    assert_receive {:EXIT, _, {%DBConnection.ConnectionError{}, [_ | _]}}
 
     assert [
-      {:connect, [_]},
-      {:handle_begin, [_, :state]},
-      {:handle_rollback, [_, :new_state]} | _] = A.record(agent)
+             {:connect, [_]},
+             {:handle_begin, [_, :state]},
+             {:handle_rollback, [_, :new_state]} | _
+           ] = A.record(agent)
   end
 
   test "transaction logs on fun raise" do
-   stack = [
+    stack = [
       {:ok, :state},
       {:ok, :began, :new_state},
-      {:ok, :rolledback, :newer_state},
-      ]
+      {:ok, :rolledback, :newer_state}
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
@@ -757,20 +856,24 @@ defmodule TransactionTest do
 
     log = &send(parent, &1)
 
-    assert_raise RuntimeError, "oops",
-      fn() ->
-        P.transaction(pool, fn(_) ->
+    assert_raise RuntimeError, "oops", fn ->
+      P.transaction(
+        pool,
+        fn _ ->
           assert_received %DBConnection.LogEntry{call: :begin, query: :begin}
           raise "oops"
-        end, [log: log])
-      end
+        end,
+        log: log
+      )
+    end
 
     assert_received %DBConnection.LogEntry{call: :rollback, query: :rollback}
 
     assert [
-      connect: [_],
-      handle_begin: [_, :state],
-      handle_rollback: [_, :new_state]] = A.record(agent)
+             connect: [_],
+             handle_begin: [_, :state],
+             handle_rollback: [_, :new_state]
+           ] = A.record(agent)
   end
 
   test "transaction logs begin status errors and disconnects" do
@@ -778,17 +881,18 @@ defmodule TransactionTest do
       {:ok, :state},
       {:transaction, :new_state},
       :ok,
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], :reconnected)
         {:ok, :newer_state}
       end,
       {:error, :newest_state},
       :ok,
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], :reconnected)
         {:ok, :state2}
       end
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
@@ -797,8 +901,8 @@ defmodule TransactionTest do
 
     log = &send(parent, &1)
 
-    assert P.transaction(pool, fn(_) -> flunk("transaction ran") end,
-      [log: log]) == {:error, :rollback}
+    assert P.transaction(pool, fn _ -> flunk("transaction ran") end, log: log) ==
+             {:error, :rollback}
 
     assert_received %DBConnection.LogEntry{call: :begin} = entry
     err = DBConnection.TransactionError.exception(:transaction)
@@ -813,8 +917,8 @@ defmodule TransactionTest do
 
     assert_receive :reconnected
 
-    assert P.transaction(pool, fn(_) -> flunk("transaction ran") end,
-      [log: log]) == {:error, :rollback}
+    assert P.transaction(pool, fn _ -> flunk("transaction ran") end, log: log) ==
+             {:error, :rollback}
 
     assert_received %DBConnection.LogEntry{call: :begin} = entry
     err = DBConnection.TransactionError.exception(:error)
@@ -829,13 +933,14 @@ defmodule TransactionTest do
     assert_receive :reconnected
 
     assert [
-      connect: [_],
-      handle_begin: [_, :state],
-      disconnect: [%DBConnection.TransactionError{status: :transaction}, :new_state],
-      connect: [_],
-      handle_begin: [_, :newer_state],
-      disconnect: [%DBConnection.TransactionError{status: :error}, :newest_state],
-      connect: [_]] = A.record(agent)
+             connect: [_],
+             handle_begin: [_, :state],
+             disconnect: [%DBConnection.TransactionError{status: :transaction}, :new_state],
+             connect: [_],
+             handle_begin: [_, :newer_state],
+             disconnect: [%DBConnection.TransactionError{status: :error}, :newest_state],
+             connect: [_]
+           ] = A.record(agent)
   end
 
   test "transaction logs commit status errors and disconnects" do
@@ -844,14 +949,15 @@ defmodule TransactionTest do
       {:ok, :began, :new_state},
       {:idle, :newer_state},
       :ok,
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], :reconnected)
         {:ok, :newest_state}
       end,
       {:ok, :began, :state2},
       {:error, :new_state2},
       {:ok, :rolledback, :newer_state2}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
@@ -860,9 +966,11 @@ defmodule TransactionTest do
 
     log = &send(parent, &1)
 
-    assert P.transaction(pool,
-      fn(_) -> assert_receive %DBConnection.LogEntry{call: :begin} end,
-      [log: log]) == {:error, :rollback}
+    assert P.transaction(
+             pool,
+             fn _ -> assert_receive %DBConnection.LogEntry{call: :begin} end,
+             log: log
+           ) == {:error, :rollback}
 
     assert_received %DBConnection.LogEntry{call: :commit} = entry
     err = DBConnection.TransactionError.exception(:idle)
@@ -875,9 +983,11 @@ defmodule TransactionTest do
     refute_received %DBConnection.LogEntry{}
     assert_receive :reconnected
 
-    assert P.transaction(pool,
-      fn(_) -> assert_receive %DBConnection.LogEntry{call: :begin} end,
-      [log: log]) == {:error, :rollback}
+    assert P.transaction(
+             pool,
+             fn _ -> assert_receive %DBConnection.LogEntry{call: :begin} end,
+             log: log
+           ) == {:error, :rollback}
 
     assert_received %DBConnection.LogEntry{call: :commit} = entry
     assert %{query: :rollback, params: nil, result: {:ok, :rolledback}} = entry
@@ -889,14 +999,15 @@ defmodule TransactionTest do
     refute_received %DBConnection.LogEntry{}
 
     assert [
-      connect: [_],
-      handle_begin: [ _, :state],
-      handle_commit: [_, :new_state],
-      disconnect: [%DBConnection.TransactionError{status: :idle}, :newer_state],
-      connect: [_],
-      handle_begin: [_, :newest_state],
-      handle_commit: [_, :state2],
-      handle_rollback: [_, :new_state2]] = A.record(agent)
+             connect: [_],
+             handle_begin: [_, :state],
+             handle_commit: [_, :new_state],
+             disconnect: [%DBConnection.TransactionError{status: :idle}, :newer_state],
+             connect: [_],
+             handle_begin: [_, :newest_state],
+             handle_commit: [_, :state2],
+             handle_rollback: [_, :new_state2]
+           ] = A.record(agent)
   end
 
   test "transaction logs rollback status error and disconnects" do
@@ -905,11 +1016,12 @@ defmodule TransactionTest do
       {:ok, :began, :new_state},
       {:idle, :newer_state},
       :ok,
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], :reconnected)
         {:ok, :newest_state}
-      end,
-      ]
+      end
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
@@ -918,12 +1030,14 @@ defmodule TransactionTest do
 
     log = &send(parent, &1)
 
-    assert P.transaction(pool,
-      fn(conn) ->
-        assert_receive %DBConnection.LogEntry{call: :begin}
-        P.rollback(conn, :oops)
-      end,
-      [log: log]) == {:error, :oops}
+    assert P.transaction(
+             pool,
+             fn conn ->
+               assert_receive %DBConnection.LogEntry{call: :begin}
+               P.rollback(conn, :oops)
+             end,
+             log: log
+           ) == {:error, :oops}
 
     assert_received %DBConnection.LogEntry{call: :rollback} = entry
     err = DBConnection.TransactionError.exception(:idle)
@@ -937,15 +1051,17 @@ defmodule TransactionTest do
     assert_receive :reconnected
 
     assert [
-      connect: [_],
-      handle_begin: [ _, :state],
-      handle_rollback: [_, :new_state],
-      disconnect: [%DBConnection.TransactionError{status: :idle}, :newer_state],
-      connect: [_]] = A.record(agent)
+             connect: [_],
+             handle_begin: [_, :state],
+             handle_rollback: [_, :new_state],
+             disconnect: [%DBConnection.TransactionError{status: :idle}, :newer_state],
+             connect: [_]
+           ] = A.record(agent)
   end
 
   test "status returns result" do
     err = RuntimeError.exception("oops")
+
     stack = [
       {:ok, :state},
       {:idle, :new_state},
@@ -953,11 +1069,12 @@ defmodule TransactionTest do
       {:error, :newest_state},
       {:disconnect, err, :state2},
       :ok,
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], :reconnected)
         {:ok, :new_state2}
-      end,
-      ]
+      end
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
@@ -971,22 +1088,23 @@ defmodule TransactionTest do
     assert_receive :reconnected
 
     assert [
-      connect: [_],
-      handle_status: [ _, :state],
-      handle_status: [_, :new_state],
-      handle_status: [_, :newer_state],
-      handle_status: [_, :newest_state],
-      disconnect: [^err, :state2],
-      connect: [_]
-      ]  = A.record(agent)
+             connect: [_],
+             handle_status: [_, :state],
+             handle_status: [_, :new_state],
+             handle_status: [_, :newer_state],
+             handle_status: [_, :newest_state],
+             disconnect: [^err, :state2],
+             connect: [_]
+           ] = A.record(agent)
   end
 
   test "status returns result on successful run" do
     stack = [
       {:ok, :state},
       {:transaction, :new_state},
-      {:transaction, :newest_state},
-      ]
+      {:transaction, :newest_state}
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
@@ -995,43 +1113,49 @@ defmodule TransactionTest do
     assert P.run(pool, fn _ -> :ok end, opts) == :ok
 
     assert [
-      connect: [_],
-      handle_status: [ _, :state],
-      handle_status: [_, :new_state]
-      ]  = A.record(agent)
+             connect: [_],
+             handle_status: [_, :state],
+             handle_status: [_, :new_state]
+           ] = A.record(agent)
   end
 
   test "status returns result on disconnect run" do
     err = RuntimeError.exception("oops")
+
     stack = [
       {:ok, :state},
       {:error, :newest_state},
       {:disconnect, err, :state2},
       :ok,
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], :reconnected)
         {:ok, :new_state2}
-      end,
-      ]
+      end
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
 
-    assert P.run(pool, fn conn ->
-      assert P.status(pool, [queue: false] ++ opts) == :error
-      assert P.status(conn, opts)
-    end, opts)
+    assert P.run(
+             pool,
+             fn conn ->
+               assert P.status(pool, [queue: false] ++ opts) == :error
+               assert P.status(conn, opts)
+             end,
+             opts
+           )
 
     assert_receive :reconnected
 
     assert [
-      connect: [_],
-      handle_status: [ _, :state],
-      handle_status: [_, :newest_state],
-      disconnect: [^err, :state2],
-      connect: [_]
-      ]  = A.record(agent)
+             connect: [_],
+             handle_status: [_, :state],
+             handle_status: [_, :newest_state],
+             disconnect: [^err, :state2],
+             connect: [_]
+           ] = A.record(agent)
   end
 
   test "status errors on unmatched run" do
@@ -1040,29 +1164,32 @@ defmodule TransactionTest do
       {:idle, :new_state},
       {:transaction, :newest_state},
       :ok,
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], :reconnected)
         {:ok, :last_state}
       end
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
 
-    assert_raise DBConnection.ConnectionError, "connection was checked out with status :idle but it was checked in with status :transaction", fn ->
-      P.run(pool, fn _ -> :ok  end)
-    end
+    assert_raise DBConnection.ConnectionError,
+                 "connection was checked out with status :idle but it was checked in with status :transaction",
+                 fn ->
+                   P.run(pool, fn _ -> :ok end)
+                 end
 
     assert_receive :reconnected
 
     assert [
-      connect: [_],
-      handle_status: [ _, :state],
-      handle_status: [_, :new_state],
-      disconnect: [_, :newest_state],
-      connect: _
-      ]  = A.record(agent)
+             connect: [_],
+             handle_status: [_, :state],
+             handle_status: [_, :new_state],
+             disconnect: [_, :newest_state],
+             connect: _
+           ] = A.record(agent)
   end
 
   test "run inside transaction" do
@@ -1072,25 +1199,27 @@ defmodule TransactionTest do
       {:ok, :committed, :newer_state},
       {:ok, :began, :newest_state},
       {:ok, :committed, :newest_state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
 
-    assert P.transaction(pool, fn(conn) ->
-      assert %DBConnection{} = conn
+    assert P.transaction(pool, fn conn ->
+             assert %DBConnection{} = conn
 
-      assert P.run(conn, fn(conn) ->
-        assert %DBConnection{} = conn
-        :result
-      end)
-    end) == {:ok, :result}
+             assert P.run(conn, fn conn ->
+                      assert %DBConnection{} = conn
+                      :result
+                    end)
+           end) == {:ok, :result}
 
     assert [
-      connect: [_],
-      handle_begin: [ _, :state],
-      handle_commit: [_, :new_state]] = A.record(agent)
+             connect: [_],
+             handle_begin: [_, :state],
+             handle_commit: [_, :new_state]
+           ] = A.record(agent)
   end
 
   test "transaction inside run" do
@@ -1100,26 +1229,28 @@ defmodule TransactionTest do
       {:ok, :began, :newer_state},
       {:ok, :committed, :newest_state},
       {:idle, :newest_state}
-      ]
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self()]
     {:ok, pool} = P.start_link(opts)
 
-    assert P.run(pool, fn(conn) ->
-      assert %DBConnection{} = conn
+    assert P.run(pool, fn conn ->
+             assert %DBConnection{} = conn
 
-      assert P.transaction(conn, fn(conn) ->
-        assert %DBConnection{} = conn
-        :result
-      end)
-    end) == {:ok, :result}
+             assert P.transaction(conn, fn conn ->
+                      assert %DBConnection{} = conn
+                      :result
+                    end)
+           end) == {:ok, :result}
 
     assert [
-      connect: [_],
-      handle_status: [_, :state],
-      handle_begin: [_, :new_state],
-      handle_commit: [_, :newer_state],
-      handle_status: [_, :newest_state]] = A.record(agent)
+             connect: [_],
+             handle_status: [_, :state],
+             handle_begin: [_, :new_state],
+             handle_commit: [_, :newer_state],
+             handle_status: [_, :newest_state]
+           ] = A.record(agent)
   end
 end

--- a/integration_test/connection_pool/all_test.exs
+++ b/integration_test/connection_pool/all_test.exs
@@ -1,1 +1,1 @@
-Code.require_file "../tests.exs", __DIR__
+Code.require_file("../tests.exs", __DIR__)

--- a/integration_test/connection_pool/disconnect_all_test.exs
+++ b/integration_test/connection_pool/disconnect_all_test.exs
@@ -54,7 +54,7 @@ defmodule TestPoolDisconnectAll do
       end,
       {:ok, :final_state},
       {:ok, %Q{}, %R{}, :final_state1},
-      {:ok, %Q{}, %R{}, :final_state2},
+      {:ok, %Q{}, %R{}, :final_state2}
     ]
 
     {:ok, agent} = A.start_link(stack)

--- a/integration_test/ownership/all_test.exs
+++ b/integration_test/ownership/all_test.exs
@@ -1,1 +1,1 @@
-Code.require_file "../tests.exs", __DIR__
+Code.require_file("../tests.exs", __DIR__)

--- a/integration_test/ownership/owner_test.exs
+++ b/integration_test/ownership/owner_test.exs
@@ -12,43 +12,51 @@ defmodule OwnerTest do
       {:ok, :state},
       {:idle, :state},
       :ok,
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], :reconnected)
         {:ok, :state}
-      end]
+      end
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     opts = [agent: agent, parent: self(), ownership_mode: :manual]
     {:ok, pool} = P.start_link(opts)
 
     parent = self()
-    {:ok, owner} = Task.start(fn() ->
-      :ok = Ownership.ownership_checkout(pool, [])
-      :ok = Ownership.ownership_allow(pool, self(), parent, [])
-      send parent, :allowed
-      Process.sleep(:infinity)
-    end)
+
+    {:ok, owner} =
+      Task.start(fn ->
+        :ok = Ownership.ownership_checkout(pool, [])
+        :ok = Ownership.ownership_allow(pool, self(), parent, [])
+        send(parent, :allowed)
+        Process.sleep(:infinity)
+      end)
 
     assert_receive :allowed
 
     log =
       capture_log(fn ->
-        assert P.run(pool, fn(_) ->
-          Process.exit(owner, :shutdown)
-          assert_receive :reconnected
-          :ok
-        end) == :ok
+        assert P.run(pool, fn _ ->
+                 Process.exit(owner, :shutdown)
+                 assert_receive :reconnected
+                 :ok
+               end) == :ok
       end)
 
     assert log =~ ~r"owner #PID<\d+\.\d+\.\d+> exited"
-    assert log =~ ~r"Client #PID<\d+\.\d+\.\d+> is still using a connection from owner at location"
+
+    assert log =~
+             ~r"Client #PID<\d+\.\d+\.\d+> is still using a connection from owner at location"
+
     assert log =~ ~r"The connection itself was checked out by #PID<\d+\.\d+\.\d+> at location"
 
     assert [
-      {:connect, _},
-      {:handle_status, _},
-      {:disconnect, _},
-      {:connect, _}] = A.record(agent)
+             {:connect, _},
+             {:handle_status, _},
+             {:disconnect, _},
+             {:connect, _}
+           ] = A.record(agent)
   end
 
   test "reconnects when ownership times out" do
@@ -56,41 +64,46 @@ defmodule OwnerTest do
       {:ok, :state},
       {:idle, :state},
       :ok,
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], :reconnected)
         {:ok, :state}
       end,
       {:idle, :state},
-      {:idle, :state}]
+      {:idle, :state}
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
     opts = [agent: agent, parent: parent]
     {:ok, pool} = P.start_link(opts)
 
-    pid = spawn_link(fn() ->
-      assert_receive {:go, ^parent}
-      assert P.run(pool, fn(_) -> :result end, opts) == :result
-      send(parent, {:done, self()})
-    end)
+    pid =
+      spawn_link(fn ->
+        assert_receive {:go, ^parent}
+        assert P.run(pool, fn _ -> :result end, opts) == :result
+        send(parent, {:done, self()})
+      end)
 
-    :ok = Ownership.ownership_checkout(pool, [ownership_timeout: 100])
+    :ok = Ownership.ownership_checkout(pool, ownership_timeout: 100)
 
     assert capture_log(fn ->
-      P.run(pool, fn(_) ->
-        assert_receive :reconnected
-        send(pid, {:go, parent})
-        assert_receive {:done, ^pid}
-      end)
-    end) =~ ~r"owner #PID<\d+\.\d+\.\d+> timed out because it owned the connection for longer than 100ms"
+             P.run(pool, fn _ ->
+               assert_receive :reconnected
+               send(pid, {:go, parent})
+               assert_receive {:done, ^pid}
+             end)
+           end) =~
+             ~r"owner #PID<\d+\.\d+\.\d+> timed out because it owned the connection for longer than 100ms"
 
     assert [
-      {:connect, _},
-      {:handle_status, _},
-      {:disconnect, _},
-      {:connect, _},
-      {:handle_status, _},
-      {:handle_status, _}] = A.record(agent)
+             {:connect, _},
+             {:handle_status, _},
+             {:disconnect, _},
+             {:connect, _},
+             {:handle_status, _},
+             {:handle_status, _}
+           ] = A.record(agent)
   end
 
   test "reconnects when client times out through owner" do
@@ -98,10 +111,12 @@ defmodule OwnerTest do
       {:ok, :state},
       {:idle, :state},
       :ok,
-      fn(opts) ->
+      fn opts ->
         send(opts[:parent], :reconnected)
         {:ok, :state}
-      end]
+      end
+    ]
+
     {:ok, agent} = A.start_link(stack)
 
     parent = self()
@@ -111,15 +126,20 @@ defmodule OwnerTest do
     :ok = Ownership.ownership_checkout(pool, [])
 
     assert capture_log(fn ->
-      P.run(pool, fn(_) ->
-        assert_receive :reconnected
-      end, timeout: 0)
-    end) =~ ~r"client #PID<\d+\.\d+\.\d+> timed out"
+             P.run(
+               pool,
+               fn _ ->
+                 assert_receive :reconnected
+               end,
+               timeout: 0
+             )
+           end) =~ ~r"client #PID<\d+\.\d+\.\d+> timed out"
 
     assert [
-      {:connect, _},
-      {:handle_status, _},
-      {:disconnect, _},
-      {:connect, _}] = A.record(agent)
+             {:connect, _},
+             {:handle_status, _},
+             {:disconnect, _},
+             {:connect, _}
+           ] = A.record(agent)
   end
 end

--- a/integration_test/ownership/test_helper.exs
+++ b/integration_test/ownership/test_helper.exs
@@ -1,4 +1,4 @@
-excludes = if Version.match?(System.version, ">= 1.8.0"), do: [], else: [:requires_callers]
+excludes = if Version.match?(System.version(), ">= 1.8.0"), do: [], else: [:requires_callers]
 
 ExUnit.start(
   capture_log: true,

--- a/integration_test/tests.exs
+++ b/integration_test/tests.exs
@@ -1,14 +1,14 @@
-Code.require_file "cases/after_connect_test.exs", __DIR__
-Code.require_file "cases/connect_test.exs", __DIR__
-Code.require_file "cases/connection_listeners_test.exs", __DIR__
-Code.require_file "cases/client_test.exs", __DIR__
-Code.require_file "cases/close_test.exs", __DIR__
-Code.require_file "cases/execute_test.exs", __DIR__
-Code.require_file "cases/idle_test.exs", __DIR__
-Code.require_file "cases/prepare_execute_test.exs", __DIR__
-Code.require_file "cases/prepare_stream_test.exs", __DIR__
-Code.require_file "cases/prepare_test.exs", __DIR__
-Code.require_file "cases/queue_test.exs", __DIR__
-Code.require_file "cases/stream_test.exs", __DIR__
-Code.require_file "cases/transaction_execute_test.exs", __DIR__
-Code.require_file "cases/transaction_test.exs", __DIR__
+Code.require_file("cases/after_connect_test.exs", __DIR__)
+Code.require_file("cases/connect_test.exs", __DIR__)
+Code.require_file("cases/connection_listeners_test.exs", __DIR__)
+Code.require_file("cases/client_test.exs", __DIR__)
+Code.require_file("cases/close_test.exs", __DIR__)
+Code.require_file("cases/execute_test.exs", __DIR__)
+Code.require_file("cases/idle_test.exs", __DIR__)
+Code.require_file("cases/prepare_execute_test.exs", __DIR__)
+Code.require_file("cases/prepare_stream_test.exs", __DIR__)
+Code.require_file("cases/prepare_test.exs", __DIR__)
+Code.require_file("cases/queue_test.exs", __DIR__)
+Code.require_file("cases/stream_test.exs", __DIR__)
+Code.require_file("cases/transaction_execute_test.exs", __DIR__)
+Code.require_file("cases/transaction_test.exs", __DIR__)


### PR DESCRIPTION
I’m not sure if it was intentional or not, but the rest of the library is formatted, so I figured this would make sense.