### PR TITLE
Raise RuntimeError on bad return values

### DIFF
--- a/integration_test/cases/after_connect_test.exs
+++ b/integration_test/cases/after_connect_test.exs
@@ -174,7 +174,7 @@ defmodule AfterConnectTest do
            ] = A.record(agent)
   end
 
-  test "after_connect execute bad return raises DBConnection.ConnectionError" do
+  test "after_connect execute bad return raises RuntimeError" do
     stack = [
       fn opts ->
         send(opts[:parent], {:hi, self()})
@@ -196,7 +196,7 @@ defmodule AfterConnectTest do
       send(parent, {:after_connect, self()})
       _ = Process.put(:agent, agent)
 
-      assert_raise DBConnection.ConnectionError, "bad return value: :oops", fn ->
+      assert_raise RuntimeError, "bad return value: :oops", fn ->
         P.execute(conn, %Q{}, [:after_connect])
       end
 
@@ -213,7 +213,7 @@ defmodule AfterConnectTest do
 
     prefix =
       "client #{inspect(after_pid)} stopped: " <>
-        "** (DBConnection.ConnectionError) bad return value: :oops"
+        "** (RuntimeError) bad return value: :oops"
 
     len = byte_size(prefix)
 

--- a/integration_test/cases/execute_test.exs
+++ b/integration_test/cases/execute_test.exs
@@ -346,7 +346,7 @@ defmodule ExecuteTest do
            ] = A.record(agent)
   end
 
-  test "execute bad return raises DBConnection.ConnectionError and stops" do
+  test "execute bad return raises RuntimeError and stops" do
     stack = [
       fn opts ->
         send(opts[:parent], {:hi, self()})
@@ -365,13 +365,13 @@ defmodule ExecuteTest do
 
     Process.flag(:trap_exit, true)
 
-    assert_raise DBConnection.ConnectionError, "bad return value: :oops", fn ->
+    assert_raise RuntimeError, "bad return value: :oops", fn ->
       P.execute(pool, %Q{}, [:param])
     end
 
     prefix =
       "client #{inspect(self())} stopped: " <>
-        "** (DBConnection.ConnectionError) bad return value: :oops"
+        "** (RuntimeError) bad return value: :oops"
 
     len = byte_size(prefix)
 

--- a/integration_test/cases/prepare_stream_test.exs
+++ b/integration_test/cases/prepare_stream_test.exs
@@ -278,7 +278,7 @@ defmodule PrepareStreamTest do
     assert P.transaction(pool, fn conn ->
              stream = P.prepare_stream(conn, %Q{}, [:param])
 
-             assert_raise DBConnection.ConnectionError, "bad return value: :oops", fn ->
+             assert_raise RuntimeError, "bad return value: :oops", fn ->
                Enum.to_list(stream)
              end
 
@@ -287,7 +287,7 @@ defmodule PrepareStreamTest do
 
     prefix =
       "client #{inspect(self())} stopped: " <>
-        "** (DBConnection.ConnectionError) bad return value: :oops"
+        "** (RuntimeError) bad return value: :oops"
 
     len = byte_size(prefix)
 

--- a/integration_test/cases/stream_test.exs
+++ b/integration_test/cases/stream_test.exs
@@ -424,7 +424,7 @@ defmodule StreamTest do
     assert P.transaction(pool, fn conn ->
              stream = P.stream(conn, %Q{}, [:param])
 
-             assert_raise DBConnection.ConnectionError, "bad return value: :oops", fn ->
+             assert_raise RuntimeError, "bad return value: :oops", fn ->
                Enum.to_list(stream)
              end
 
@@ -433,7 +433,7 @@ defmodule StreamTest do
 
     prefix =
       "client #{inspect(self())} stopped: " <>
-        "** (DBConnection.ConnectionError) bad return value: :oops"
+        "** (RuntimeError) bad return value: :oops"
 
     len = byte_size(prefix)
 
@@ -555,7 +555,7 @@ defmodule StreamTest do
     assert P.transaction(pool, fn conn ->
              stream = P.stream(conn, %Q{}, [:param])
 
-             assert_raise DBConnection.ConnectionError, "bad return value: :oops", fn ->
+             assert_raise RuntimeError, "bad return value: :oops", fn ->
                Enum.to_list(stream)
              end
 
@@ -564,7 +564,7 @@ defmodule StreamTest do
 
     prefix =
       "client #{inspect(self())} stopped: " <>
-        "** (DBConnection.ConnectionError) bad return value: :oops"
+        "** (RuntimeError) bad return value: :oops"
 
     len = byte_size(prefix)
 

--- a/integration_test/cases/transaction_execute_test.exs
+++ b/integration_test/cases/transaction_execute_test.exs
@@ -180,7 +180,7 @@ defmodule TransactionExecuteTest do
            ] = A.record(agent)
   end
 
-  test "execute bad return raises DBConnection.ConnectionError and stops" do
+  test "execute bad return raises RuntimeError and stops" do
     stack = [
       fn opts ->
         send(opts[:parent], {:hi, self()})
@@ -201,7 +201,7 @@ defmodule TransactionExecuteTest do
     Process.flag(:trap_exit, true)
 
     assert P.transaction(pool, fn conn ->
-             assert_raise DBConnection.ConnectionError,
+             assert_raise RuntimeError,
                           "bad return value: :oops",
                           fn -> P.execute(conn, %Q{}, [:param]) end
 
@@ -214,7 +214,7 @@ defmodule TransactionExecuteTest do
 
     prefix =
       "client #{inspect(self())} stopped: " <>
-        "** (DBConnection.ConnectionError) bad return value: :oops"
+        "** (RuntimeError) bad return value: :oops"
 
     len = byte_size(prefix)
 
@@ -337,8 +337,9 @@ defmodule TransactionExecuteTest do
       fn conn ->
         assert_received %DBConnection.LogEntry{call: :begin, query: :begin}
 
-        assert_raise DBConnection.ConnectionError,
-                     fn -> P.execute(conn, %Q{}, [:param]) end
+        assert_raise RuntimeError, "bad return value: :oops", fn ->
+          P.execute(conn, %Q{}, [:param])
+        end
       end,
       log: log
     )

--- a/integration_test/cases/transaction_test.exs
+++ b/integration_test/cases/transaction_test.exs
@@ -451,13 +451,13 @@ defmodule TransactionTest do
 
     Process.flag(:trap_exit, true)
 
-    assert_raise DBConnection.ConnectionError, "bad return value: :oops", fn ->
+    assert_raise RuntimeError, "bad return value: :oops", fn ->
       P.transaction(pool, fn _ -> flunk("transaction ran") end)
     end
 
     prefix =
       "client #{inspect(self())} stopped: " <>
-        "** (DBConnection.ConnectionError) bad return value: :oops"
+        "** (RuntimeError) bad return value: :oops"
 
     len = byte_size(prefix)
 
@@ -633,13 +633,13 @@ defmodule TransactionTest do
 
     Process.flag(:trap_exit, true)
 
-    assert_raise DBConnection.ConnectionError, "bad return value: :oops", fn ->
+    assert_raise RuntimeError, "bad return value: :oops", fn ->
       P.transaction(pool, fn _ -> :result end)
     end
 
     prefix =
       "client #{inspect(self())} stopped: " <>
-        "** (DBConnection.ConnectionError) bad return value: :oops"
+        "** (RuntimeError) bad return value: :oops"
 
     len = byte_size(prefix)
 

--- a/integration_test/ownership/manager_test.exs
+++ b/integration_test/ownership/manager_test.exs
@@ -629,7 +629,7 @@ defmodule ManagerTest do
       capture_log(fn ->
         assert Ownership.ownership_checkout(pool, pre_checkin: pre_checkin) == :ok
 
-        assert_raise DBConnection.ConnectionError, "bad return value: :oops", fn ->
+        assert_raise RuntimeError, "bad return value: :oops", fn ->
           assert_checked_out(pool, opts)
         end
 

--- a/lib/db_connection.ex
+++ b/lib/db_connection.ex
@@ -1282,7 +1282,7 @@ defmodule DBConnection do
 
   defp bad_return!(other, conn, meter) do
     try do
-      raise DBConnection.ConnectionError, "bad return value: #{inspect(other)}"
+      raise "bad return value: #{inspect(other)}"
     catch
       :error, reason ->
         stack = __STACKTRACE__


### PR DESCRIPTION
As mentioned in #281. cc @wojtekmach, I went with `RuntimeError`, which I think makes more sense here than `ArgumentError`.