### PR TITLE
Small doc fix on ping callback

### DIFF
--- a/lib/db_connection.ex
+++ b/lib/db_connection.ex
@@ -175,7 +175,7 @@ defmodule DBConnection do
 
   This callback is called if no callbacks have been called after the
   idle timeout and a client process is not using the state. The idle
-  timeout can be configured by the `:idle_interval` and `:idle_interval`
+  timeout can be configured by the `:idle_interval` and `:idle_limit`
   options. This function can be called whether the connection is checked
   in or checked out.
 


### PR DESCRIPTION
`idle_interval` option was repeated in sentence. Should be `idle_interval` and `idle_limit`.