### PR TITLE
Add DBConnection.available_start_options/0

### DIFF
--- a/lib/db_connection.ex
+++ b/lib/db_connection.ex
@@ -522,6 +522,39 @@ defmodule DBConnection do
   end
 
   @doc """
+  Returns the names of all possible options that you can pass to `start_link/2`.
+
+  This is mostly useful for library authors that base their library on top of
+  `DBConnection`, since they can use the return value of this function to perform
+  validation on options only passing down these options to DBConnection.
+
+  See also `t:start_option/0`.
+  """
+  @doc since: "2.6.0"
+  @spec available_start_options() :: [atom, ...]
+  def available_start_options do
+    [
+      :after_connect,
+      :after_connect_timeout,
+      :connection_listeners,
+      :backoff_max,
+      :backoff_min,
+      :backoff_type,
+      :configure,
+      :idle_interval,
+      :idle_limit,
+      :max_restarts,
+      :max_seconds,
+      :name,
+      :pool,
+      :pool_size,
+      :queue_interval,
+      :queue_target,
+      :show_sensitive_data_on_connection_error
+    ]
+  end
+
+  @doc """
   Forces all connections in the pool to disconnect within the given interval
   in milliseconds.
 

--- a/test/db_connection_test.exs
+++ b/test/db_connection_test.exs
@@ -32,6 +32,30 @@ defmodule DBConnectionTest do
     assert A.record(agent) == [{:connect, [[pool_index: 1] ++ opts]}]
   end
 
+  describe "available_start_options/0" do
+    test "returns all available start_link/2 options" do
+      assert DBConnection.available_start_options() == [
+               :after_connect,
+               :after_connect_timeout,
+               :connection_listeners,
+               :backoff_max,
+               :backoff_min,
+               :backoff_type,
+               :configure,
+               :idle_interval,
+               :idle_limit,
+               :max_restarts,
+               :max_seconds,
+               :name,
+               :pool,
+               :pool_size,
+               :queue_interval,
+               :queue_target,
+               :show_sensitive_data_on_connection_error
+             ]
+    end
+  end
+
   describe "connection_module/1" do
     test "returns the connection module when given a pool pid" do
       {:ok, pool} = P.start_link([])


### PR DESCRIPTION
This would be awesome in [Xandra](https://github.com/lexhide/xandra) for example, because we could split start options in

1. Xandra options, which we validate
2. DBConnection options, which we pass down to DBConnection
3. Any other option, for which we'd raise as "unknown option"

If this is a good addition, I can do the same for `t:DBConnection.option/0`.