### PR TITLE
Add DBConnection.ConnectionError.t/0 type

### DIFF
--- a/lib/db_connection/connection.ex
+++ b/lib/db_connection/connection.ex
@@ -1,21 +1,3 @@
-defmodule DBConnection.ConnectionError do
-  defexception [:message, severity: :error, reason: :error]
-
-  @moduledoc """
-  A generic connection error exception.
-
-  The raised exception might include the reason which would be useful
-  to programmatically determine what was causing the error.
-  """
-
-  @doc false
-  def exception(message, reason) do
-    message
-    |> exception()
-    |> Map.replace!(:reason, reason)
-  end
-end
-
 defmodule DBConnection.Connection do
   @moduledoc false
 

--- a/lib/db_connection/connection_error.ex
+++ b/lib/db_connection/connection_error.ex
@@ -1,0 +1,24 @@
+defmodule DBConnection.ConnectionError do
+  @moduledoc """
+  A generic connection error exception.
+
+  The raised exception might include the reason which would be useful
+  to programmatically determine what was causing the error.
+  """
+
+  @typedoc since: "2.7.0"
+  @type t() :: %__MODULE__{
+          message: String.t(),
+          reason: :error | :queue_timeout,
+          severity: Logger.level()
+        }
+
+  defexception [:message, severity: :error, reason: :error]
+
+  @doc false
+  def exception(message, reason) when is_binary(message) and reason in [:error, :queue_timeout] do
+    message
+    |> exception()
+    |> Map.replace!(:reason, reason)
+  end
+end


### PR DESCRIPTION
I also moved the connection error definition into its own file and added some guards to its `exception/2` function.

The idea here is to lay the foundations for expanding `:reason` so that programmers can gather more from that instead of sometimes having to match on the message.