### PR TITLE
Fix compiler warnings in Elixir 1.17

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -10,6 +10,7 @@ defmodule DBConnection.Mixfile do
       app: :db_connection,
       version: @version,
       elixir: "~> 1.8",
+      compilers: [:yecc] ++ Mix.compilers(),
       deps: deps(),
       docs: docs(),
       description: description(),


### PR DESCRIPTION
I've tried to run my project with the new Elixir 1.17-rc.0 and got this warning.

```elixir
==> db_connection
Compiling 15 files (.ex)
Generated db_connection app
warning: in order to compile .yrl files, you must add "compilers: [:yecc] ++ Mix.compilers()" to the "def project" section of expo's mix.exs
  (mix 1.17.0-rc.0) lib/mix/tasks/compile.yecc.ex:70: Mix.Tasks.Compile.Yecc.preload/1
  (mix 1.17.0-rc.0) lib/mix/compilers/erlang.ex:66: Mix.Compilers.Erlang.compile/6
  (mix 1.17.0-rc.0) lib/mix/task.ex:495: anonymous fn/3 in Mix.Task.run_task/5
  (mix 1.17.0-rc.0) lib/mix/tasks/compile.all.ex:108: Mix.Tasks.Compile.All.run_compiler/2
  (mix 1.17.0-rc.0) lib/mix/tasks/compile.all.ex:88: Mix.Tasks.Compile.All.compile/4
  (mix 1.17.0-rc.0) lib/mix/tasks/compile.all.ex:62: Mix.Tasks.Compile.All.run/1
```