### PR TITLE
Fix typos again

### DIFF
--- a/lib/db_connection.ex
+++ b/lib/db_connection.ex
@@ -539,7 +539,7 @@ defmodule DBConnection do
 
   The allowed callbacks are:
 
-    * A 1-arity function that recieves the options from `start_link/2` as well as
+    * A 1-arity function that receives the options from `start_link/2` as well as
       `:pool_index`
     * `{module, function, args}` where the options from `start_link/2` as well as
       `:pool_index` are prepended to `args` before the function is called

--- a/lib/db_connection/connection.ex
+++ b/lib/db_connection/connection.ex
@@ -340,7 +340,7 @@ defmodule DBConnection.Connection do
 
   @doc false
   @impl :gen_statem
-  # If client is :closed then the connection was previouly disconnected
+  # If client is :closed then the connection was previously disconnected
   # and cleanup is not required.
   def terminate(_, _, %{client: :closed}), do: :ok
 


### PR DESCRIPTION
Found via `typos --hidden --format brief`