### PR TITLE
Add a telemetry event on connect/disconnect

### DIFF
--- a/lib/db_connection/app.ex
+++ b/lib/db_connection/app.ex
@@ -6,6 +6,7 @@ defmodule DBConnection.App do
   def start(_type, _args) do
     children = [
       {Task.Supervisor, name: DBConnection.Task},
+      DBConnection.NotifyListeners,
       dynamic_supervisor(DBConnection.Ownership.Supervisor),
       dynamic_supervisor(DBConnection.ConnectionPool.Supervisor),
       DBConnection.Watcher

--- a/lib/db_connection/connection.ex
+++ b/lib/db_connection/connection.ex
@@ -144,6 +144,12 @@ defmodule DBConnection.Connection do
       :ok
     end
 
+    :telemetry.execute(
+      [:db_connection, :disconnect],
+      %{count: 1},
+      %{mod: mod, opts: s.opts, pool: s.pool}
+    )
+
     %{state: state, client: client, timer: timer, backoff: backoff} = s
     demonitor(client)
     cancel_timer(timer)

--- a/lib/db_connection/notify_listeners.ex
+++ b/lib/db_connection/notify_listeners.ex
@@ -1,0 +1,109 @@
+defmodule DBConnection.NotifyListeners do
+  @moduledoc false
+  # This server is responsible for:
+  # - Handling requests to add connection listeners to a connection
+  # - Attaching a telemetry handler to forward messages to connection
+  # listeners (but the forwarding is performed at the connection process)
+  # - Automatically removing connection listeners for connections that were removed,
+  # and detaching the telemetry handler if it's not needed anymore
+
+  use GenServer
+
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, [], name: server_name())
+  end
+
+  def add_listeners(_, []) do
+    :ok
+  end
+
+  def add_listeners(connection_pid, listeners) do
+    GenServer.call(server_name(), {:add_listeners, connection_pid, listeners})
+  end
+
+  @impl GenServer
+  def init(_opts) do
+    start_ets()
+    {:ok, %{attached?: false}}
+  end
+
+  @impl GenServer
+  def handle_info({:DOWN, _, :process, pid, _}, state) do
+    :ets.delete(ets_name(), pid)
+
+    case maybe_detach_handlers() do
+      :detached -> {:noreply, %{state | attached?: false}}
+      :attached -> {:noreply, state}
+    end
+  end
+
+  @impl GenServer
+  def handle_call({:add_listeners, connection_pid, listeners}, _from, state) do
+    unless state.attached? do
+      attach_handlers()
+    end
+
+    :ets.insert(ets_name(), {connection_pid, listeners})
+    Process.monitor(connection_pid)
+
+    {:reply, :ok, %{state | attached?: true}}
+  end
+
+  defp maybe_detach_handlers() do
+    case :ets.info(ets_name()) do
+      %{size: 0} ->
+        detach_handlers()
+        :detached
+
+      _ ->
+        :attached
+    end
+  end
+
+  defp start_ets() do
+    :ets.new(ets_name(), [:public, :named_table])
+  end
+
+  defp attach_handlers() do
+    :telemetry.attach_many(
+      handler_name(),
+      [
+        [:db_connection, :connected],
+        [:db_connection, :disconnected]
+      ],
+      &__MODULE__.notify_listeners/4,
+      %{}
+    )
+  end
+
+  defp detach_handlers() do
+    :telemetry.detach(handler_name())
+  end
+
+  def notify_listeners([:db_connection, :connected], _, _, _) do
+    do_notify_listeners(:connected, self())
+  end
+
+  def notify_listeners([:db_connection, :disconnected], _, _, _) do
+    do_notify_listeners(:disconnected, self())
+  end
+
+  defp do_notify_listeners(action, conn_pid) do
+    [{_, connection_listeners}] = :ets.lookup(ets_name(), conn_pid)
+
+    {listeners, message} =
+      case connection_listeners do
+        listeners when is_list(listeners) ->
+          {listeners, {action, conn_pid}}
+
+        {listeners, tag} when is_list(listeners) ->
+          {listeners, {action, conn_pid, tag}}
+      end
+
+    Enum.each(listeners, &send(&1, message))
+  end
+
+  defp ets_name(), do: __MODULE__.Ets
+  defp handler_name(), do: inspect(__MODULE__.TelemetryHandler)
+  defp server_name(), do: __MODULE__
+end


### PR DESCRIPTION
Adds a telemetry event on connection/disconnection.

Moves the logic of notifying listeners to a telemetry handler.