### PR TITLE
Use process labels

### DIFF
--- a/lib/db_connection/connection.ex
+++ b/lib/db_connection/connection.ex
@@ -48,6 +48,10 @@ defmodule DBConnection.Connection do
   @doc false
   @impl :gen_statem
   def init({mod, opts, pool, tag}) do
+    pool_index = Keyword.get(opts, :pool_index)
+    label = if pool_index, do: "db_conn_#{pool_index}", else: "db_conn"
+    Util.set_label(label)
+
     s = %{
       mod: mod,
       opts: opts,

--- a/lib/db_connection/connection_pool.ex
+++ b/lib/db_connection/connection_pool.ex
@@ -10,6 +10,7 @@ defmodule DBConnection.ConnectionPool do
 
   use GenServer
   alias DBConnection.Holder
+  alias DBConnection.Util
 
   @behaviour DBConnection.Pool
 
@@ -131,7 +132,7 @@ defmodule DBConnection.ConnectionPool do
   end
 
   def handle_info({:"ETS-TRANSFER", holder, pid, queue}, {_, queue, _, _} = data) do
-    message = "client #{inspect(pid)} exited"
+    message = "client #{Util.inspect_pid(pid)} exited"
     err = DBConnection.ConnectionError.exception(message: message, severity: :info)
     Holder.handle_disconnect(holder, err)
     {:noreply, data}
@@ -170,14 +171,14 @@ defmodule DBConnection.ConnectionPool do
     # Check that timeout refers to current holder (and not previous)
     if Holder.handle_deadline(holder, deadline) do
       message =
-        "client #{inspect(pid)} timed out because " <>
+        "client #{Util.inspect_pid(pid)} timed out because " <>
           "it queued and checked out the connection for longer than #{len}ms"
 
       exc =
         case Process.info(pid, :current_stacktrace) do
           {:current_stacktrace, stacktrace} ->
             message <>
-              "\n\n#{inspect(pid)} was at location:\n\n" <>
+              "\n\n#{Util.inspect_pid(pid)} was at location:\n\n" <>
               Exception.format_stacktrace(stacktrace)
 
           _ ->

--- a/lib/db_connection/ownership/manager.ex
+++ b/lib/db_connection/ownership/manager.ex
@@ -3,6 +3,7 @@ defmodule DBConnection.Ownership.Manager do
   use GenServer
   require Logger
   alias DBConnection.Ownership.Proxy
+  alias DBConnection.Util
 
   @timeout 5_000
 
@@ -366,7 +367,7 @@ defmodule DBConnection.Ownership.Manager do
 
   defp not_found({pid, _} = from) do
     msg = """
-    cannot find ownership process for #{inspect(pid)}.
+    cannot find ownership process for #{Util.inspect_pid(pid)}.
 
     When using ownership, you must manage connections in one
     of the four ways:

--- a/lib/db_connection/ownership/proxy.ex
+++ b/lib/db_connection/ownership/proxy.ex
@@ -22,6 +22,8 @@ defmodule DBConnection.Ownership.Proxy do
 
   @impl true
   def init({caller, pool, pool_opts}) do
+    Util.set_label("db_ownership_proxy")
+
     pool_opts =
       pool_opts
       |> Keyword.put(:timeout, :infinity)

--- a/lib/db_connection/ownership/proxy.ex
+++ b/lib/db_connection/ownership/proxy.ex
@@ -2,6 +2,7 @@ defmodule DBConnection.Ownership.Proxy do
   @moduledoc false
 
   alias DBConnection.Holder
+  alias DBConnection.Util
   use GenServer, restart: :temporary
 
   @time_unit 1000
@@ -58,13 +59,13 @@ defmodule DBConnection.Ownership.Proxy do
 
   @impl true
   def handle_info({:DOWN, ref, _, pid, _reason}, %{owner: {_, ref}} = state) do
-    down("owner #{inspect(pid)} exited", state)
+    down("owner #{Util.inspect_pid(pid)} exited", state)
   end
 
   def handle_info({:timeout, deadline, {_ref, holder, pid, len}}, %{holder: holder} = state) do
     if Holder.handle_deadline(holder, deadline) do
       message =
-        "client #{inspect(pid)} timed out because " <>
+        "client #{Util.inspect_pid(pid)} timed out because " <>
           "it queued and checked out the connection for longer than #{len}ms"
 
       down(message, state)
@@ -78,7 +79,7 @@ defmodule DBConnection.Ownership.Proxy do
         %{ownership_timer: timer} = state
       ) do
     message =
-      "owner #{inspect(pid)} timed out because " <>
+      "owner #{Util.inspect_pid(pid)} timed out because " <>
         "it owned the connection for longer than #{timeout}ms (set via the :ownership_timeout option)"
 
     # We don't invoke down because this is always a disconnect, even if there is no client.
@@ -150,7 +151,7 @@ defmodule DBConnection.Ownership.Proxy do
   end
 
   def handle_info({:"ETS-TRANSFER", holder, pid, ref}, %{holder: holder, owner: {_, ref}} = state) do
-    down("client #{inspect(pid)} exited", state)
+    down("client #{Util.inspect_pid(pid)} exited", state)
   end
 
   @impl true

--- a/lib/db_connection/task.ex
+++ b/lib/db_connection/task.ex
@@ -13,6 +13,8 @@ defmodule DBConnection.Task do
   end
 
   def init(fun, parent, opts) do
+    DBConnection.Util.set_label("db_after_connect_task")
+
     try do
       Process.link(parent)
     catch

--- a/lib/db_connection/util.ex
+++ b/lib/db_connection/util.ex
@@ -1,0 +1,29 @@
+defmodule DBConnection.Util do
+  @moduledoc """
+  Shared functions.
+  """
+
+  @doc """
+  Inspect a pid, including the process label if possible.
+  """
+  def inspect_pid(pid) do
+    case get_label(pid) do
+      :undefined -> inspect(pid)
+      label -> "#{inspect(pid)} (#{inspect(label)})"
+    end
+  end
+
+  defp get_label(pid) do
+    if function_exported?(:proc_lib, :get_label, 1) do
+      # Avoid a compiler warning if the function isn't
+      # defined in your version of Erlang/OTP
+      apply(:proc_lib, :get_label, [pid])
+    else
+      # mimic return value of
+      # `:proc_lib.get_label/1` when none is set.
+      # Don't resort to using `Process.info(pid, :dictionary)`,
+      # as this is not efficient.
+      :undefined
+    end
+  end
+end

--- a/lib/db_connection/util.ex
+++ b/lib/db_connection/util.ex
@@ -13,6 +13,18 @@ defmodule DBConnection.Util do
     end
   end
 
+  @doc """
+  Set a process label if `Process.set_label/1` is available.
+  """
+  def set_label(label) do
+    if function_exported?(Process, :set_label, 1) do
+      Process.set_label(label)
+    else
+      :ok
+    end
+  end
+
+  # Get a process label if `:proc_lib.get_label/1` is available.
   defp get_label(pid) do
     if function_exported?(:proc_lib, :get_label, 1) do
       # Avoid a compiler warning if the function isn't


### PR DESCRIPTION
This probably needs tweaking, but I periodically see people asking (and have wondered myself) how to figure out which test in a suite is responsible for something like

```
18:09:26.437 [error] Postgrex.Protocol (#PID<0.413.0>) disconnected: ** (DBConnection.ConnectionError) client #PID<0.2759.0> exited
```

This is an attempt to make our systems and their errors easier to understand.