### PR TITLE
Remove sensitive options before calling after_connect

### DIFF
--- a/lib/db_connection/connection.ex
+++ b/lib/db_connection/connection.ex
@@ -9,7 +9,7 @@ defmodule DBConnection.Connection do
   alias DBConnection.Util
 
   @timeout 15_000
-  @sensitive_opts [:after_connect, :parameters, :hostname, :port, :username, :password, :database]
+  @sensitive_opts [:parameters, :hostname, :port, :username, :password, :database]
 
   @doc false
   def start_link(mod, opts, pool, tag) do


### PR DESCRIPTION
Closes https://github.com/elixir-ecto/db_connection/issues/335

The issue is that all of the connection options are passed to `after_connect`. And if that fails for some reason it can be logged out in the stack trace. 

There are a few ways that this could have been handled. I'll explain them briefly and why I went with the current approach:

1. Make the `show_sensitive_connection_data...` option apply to `after_connect`. This didn't seem appropriate because there is nothing inherently sensitive about `after_connect`. It could be any random query.
2. Try to make an inclusion list of options to keep in `after_connect`. This felt a bit risky to me because I don't know what can/will be useful in the future from all of the repo options we currently let people set or will let them set in the future. 
3. Make an exclusion list of options to remove before calling `after_connect`. The risk here is we miss certain things or forget to update the list as new sensitive options are added.

I chose option 3 because it seemed the least likely to cause regressions. It doesn't seem super likely that we will add a lot of new sensitive options to the connection.

I'm on the fence about changing it to option 2 though because it might be obvious to someone else what the inclusion list should be.