### PR TITLE
Fix Watcher blocking during slow pool termination

### DIFF
--- a/lib/db_connection/watcher.ex
+++ b/lib/db_connection/watcher.ex
@@ -38,13 +38,12 @@ defmodule DBConnection.Watcher do
   def handle_info({:DOWN, ref, _, _, _}, {caller_refs, started_refs}) do
     case caller_refs do
       %{^ref => {_supervisor, started_pid, started_ref}} ->
-        Task.Supervisor.start_child(DBConnection.Task, fn ->
-          try do
-            GenServer.stop(started_pid, :shutdown, :infinity)
-          catch
-            :exit, _ -> :ok
-          end
-        end)
+        try do
+          :sys.terminate(started_pid, :shutdown, :infinity)
+        catch
+          :exit, {:noproc, {:sys, :terminate, _}} -> :ok
+          :exit, {:shutdown, {:sys, :terminate, _}} -> :ok
+        end
 
         caller_refs = Map.delete(caller_refs, ref)
         started_refs = Map.put(started_refs, started_ref, {nil, nil})

--- a/lib/db_connection/watcher.ex
+++ b/lib/db_connection/watcher.ex
@@ -45,6 +45,7 @@ defmodule DBConnection.Watcher do
             :exit, _ -> :ok
           end
         end)
+
         caller_refs = Map.delete(caller_refs, ref)
         started_refs = Map.put(started_refs, started_ref, {nil, nil})
         {:noreply, {caller_refs, started_refs}}

--- a/lib/db_connection/watcher.ex
+++ b/lib/db_connection/watcher.ex
@@ -69,7 +69,7 @@ defmodule DBConnection.Watcher do
 
   @impl true
   def terminate(_, {_, started_refs}) do
-    for {_, {caller_pid, _}} <- started_refs do
+    for {_, {caller_pid, _}} when caller_pid != nil <- started_refs do
       Process.exit(caller_pid, :kill)
     end
 

--- a/lib/db_connection/watcher.ex
+++ b/lib/db_connection/watcher.ex
@@ -37,16 +37,28 @@ defmodule DBConnection.Watcher do
   @impl true
   def handle_info({:DOWN, ref, _, _, _}, {caller_refs, started_refs}) do
     case caller_refs do
-      %{^ref => {supervisor, started_pid, started_ref}} ->
-        Process.demonitor(started_ref, [:flush])
-        DynamicSupervisor.terminate_child(supervisor, started_pid)
-        {:noreply, {Map.delete(caller_refs, ref), Map.delete(started_refs, started_ref)}}
+      %{^ref => {_supervisor, started_pid, started_ref}} ->
+        Task.Supervisor.start_child(DBConnection.Task, fn ->
+          try do
+            GenServer.stop(started_pid, :shutdown, :infinity)
+          catch
+            :exit, _ -> :ok
+          end
+        end)
+        caller_refs = Map.delete(caller_refs, ref)
+        started_refs = Map.put(started_refs, started_ref, {nil, nil})
+        {:noreply, {caller_refs, started_refs}}
 
       %{} ->
-        %{^ref => {caller_pid, caller_ref}} = started_refs
-        Process.demonitor(caller_ref, [:flush])
-        Process.exit(caller_pid, :kill)
-        {:noreply, {Map.delete(caller_refs, caller_ref), Map.delete(started_refs, ref)}}
+        case started_refs do
+          %{^ref => {nil, nil}} ->
+            {:noreply, {caller_refs, Map.delete(started_refs, ref)}}
+
+          %{^ref => {caller_pid, caller_ref}} ->
+            Process.demonitor(caller_ref, [:flush])
+            Process.exit(caller_pid, :kill)
+            {:noreply, {Map.delete(caller_refs, caller_ref), Map.delete(started_refs, ref)}}
+        end
     end
   end
 

--- a/test/db_connection/watcher_test.exs
+++ b/test/db_connection/watcher_test.exs
@@ -44,12 +44,9 @@ defmodule DBConnection.WatcherTest do
       end)
       |> Process.monitor()
 
-    # Trigger termination of pool1 by stopping it (the caller).
-    # This sends a :DOWN to the Watcher, which will try to terminate the pool.
+    # Trigger pool termination
     stop_supervised!(:pool1)
 
-    # Now try to start a second pool. If the Watcher is blocked by the
-    # synchronous DynamicSupervisor.terminate_child call, this will hang.
     {:ok, agent2} = A.start_link([{:ok, :state}])
 
     task =
@@ -57,9 +54,10 @@ defmodule DBConnection.WatcherTest do
         C.start_link(agent: agent2, pool_size: 1, idle_interval: 100_000)
       end)
 
-    assert {:ok, _pool2} = Task.await(task, 3_000)
+    # If the DynamicSupervisor or the watcher is blocked, this hangs
+    assert {:ok, _pool2} = Task.await(task, 1_000)
 
     # Ensure the pool supervisor actually terminates
-    assert_receive {:DOWN, ^pool_sup_ref, _, _, _}, 10_000
+    assert_receive {:DOWN, ^pool_sup_ref, _, _, _}, 5_000
   end
 end

--- a/test/db_connection/watcher_test.exs
+++ b/test/db_connection/watcher_test.exs
@@ -5,8 +5,6 @@ defmodule DBConnection.WatcherTest do
   alias TestAgent, as: A
 
   test "starting a new pool is not blocked by a slow-to-terminate pool" do
-    # Start a pool whose connection takes a long time to disconnect.
-    # The disconnect callback sleeps for 10 seconds, simulating a slow shutdown.
     {:ok, agent1} =
       A.start_link([
         {:ok, :state},
@@ -16,20 +14,39 @@ defmodule DBConnection.WatcherTest do
         end
       ])
 
-    start_supervised!(
-      %{
+    pool1 =
+      start_supervised!(%{
         id: :pool1,
-        start: {DBConnection, :start_link, [TestConnection, [agent: agent1, pool_size: 1]]},
+        start:
+          {DBConnection, :start_link,
+           [
+             TestConnection,
+             [agent: agent1, pool_size: 1, idle_interval: 100_000, shutdown: 2_500]
+           ]},
         restart: :temporary
-      }
-    )
+      })
+
+    # Find the pool sup for pool1 by matching the owner pid in child spec ids.
+    pool_sup_ref =
+      DBConnection.ConnectionPool.Supervisor
+      |> DynamicSupervisor.which_children()
+      |> Enum.find_value(fn {_, sup_pid, _, _} ->
+        try do
+          has_pool1? =
+            sup_pid
+            |> Supervisor.which_children()
+            |> Enum.any?(fn {{_mod, owner, _id}, _, _, _} -> owner == pool1 end)
+
+          if has_pool1?, do: sup_pid
+        catch
+          :exit, _ -> nil
+        end
+      end)
+      |> Process.monitor()
 
     # Trigger termination of pool1 by stopping it (the caller).
     # This sends a :DOWN to the Watcher, which will try to terminate the pool.
     stop_supervised!(:pool1)
-
-    # Give the Watcher a moment to receive the :DOWN and start terminating pool1
-    Process.sleep(100)
 
     # Now try to start a second pool. If the Watcher is blocked by the
     # synchronous DynamicSupervisor.terminate_child call, this will hang.
@@ -37,9 +54,12 @@ defmodule DBConnection.WatcherTest do
 
     task =
       Task.async(fn ->
-        C.start_link(agent: agent2, pool_size: 1)
+        C.start_link(agent: agent2, pool_size: 1, idle_interval: 100_000)
       end)
 
     assert {:ok, _pool2} = Task.await(task, 3_000)
+
+    # Ensure the pool supervisor actually terminates
+    assert_receive {:DOWN, ^pool_sup_ref, _, _, _}, 10_000
   end
 end

--- a/test/db_connection/watcher_test.exs
+++ b/test/db_connection/watcher_test.exs
@@ -1,0 +1,45 @@
+defmodule DBConnection.WatcherTest do
+  use ExUnit.Case, async: true
+
+  alias TestConnection, as: C
+  alias TestAgent, as: A
+
+  test "starting a new pool is not blocked by a slow-to-terminate pool" do
+    # Start a pool whose connection takes a long time to disconnect.
+    # The disconnect callback sleeps for 10 seconds, simulating a slow shutdown.
+    {:ok, agent1} =
+      A.start_link([
+        {:ok, :state},
+        fn _err, _state ->
+          Process.sleep(10_000)
+          :ok
+        end
+      ])
+
+    start_supervised!(
+      %{
+        id: :pool1,
+        start: {DBConnection, :start_link, [TestConnection, [agent: agent1, pool_size: 1]]},
+        restart: :temporary
+      }
+    )
+
+    # Trigger termination of pool1 by stopping it (the caller).
+    # This sends a :DOWN to the Watcher, which will try to terminate the pool.
+    stop_supervised!(:pool1)
+
+    # Give the Watcher a moment to receive the :DOWN and start terminating pool1
+    Process.sleep(100)
+
+    # Now try to start a second pool. If the Watcher is blocked by the
+    # synchronous DynamicSupervisor.terminate_child call, this will hang.
+    {:ok, agent2} = A.start_link([{:ok, :state}])
+
+    task =
+      Task.async(fn ->
+        C.start_link(agent: agent2, pool_size: 1)
+      end)
+
+    assert {:ok, _pool2} = Task.await(task, 3_000)
+  end
+end


### PR DESCRIPTION
The Watcher calls DynamicSupervisor.terminate_child/2 synchronously,
blocking all other watch/terminate operations until the pool finishes
shutting down.

This can cause applications running multiple pools to have degraded
performance when connections take long to terminate (observed in production
with Postgrex).

Added a test reproducing the issue, and a proposed fix via a Task calling
`GenServer.stop/1`.