### PR TITLE
Fix max_lifetime docstring inaccuracies, validation, and typos

### DIFF
--- a/lib/db_connection.ex
+++ b/lib/db_connection.ex
@@ -440,12 +440,12 @@ defmodule DBConnection do
 
     * `:max_lifetime` - The number of ms the connection is allowed to live.
       It is a range so you can jitter/spread disconnections over some time period.
-      For example, to have a max lifetime between 8 and 9 minutes, you ca set it
+      For example, to have a max lifetime between 8 and 9 minutes, you can set it
       to `480_000..540_000`. Because the timer is started *after* the connection
-      to the database is established and on checkout, the connection may live for
-      slightly longer. If the connection is idle, the worst case wait is of
-      `540_000 + idle_limit`. If the connection is in use, it may last as long as
-      the connection is checked out over the max period. Default is `nil`.
+      to the database is established, the connection may live for slightly longer.
+      If the connection is idle, the worst case wait is of
+      `540_000 + 2 * idle_interval`. If the connection is in use, it may last as
+      long as the connection is checked out over the max period. Default is `nil`.
 
     * `:name` - A name to register the started process (see the `:name` option
       in `GenServer.start_link/3`)

--- a/lib/db_connection/connection_pool.ex
+++ b/lib/db_connection/connection_pool.ex
@@ -57,12 +57,12 @@ defmodule DBConnection.ConnectionPool do
 
     max_lifetime =
       case Keyword.fetch(opts, :max_lifetime) do
-        {:ok, %Range{first: first, last: last, step: 1}} ->
+        {:ok, %Range{first: first, last: last, step: 1}} when first >= 0 and last >= first ->
           {System.convert_time_unit(first, :millisecond, :native), last - first}
 
         {:ok, invalid} ->
           raise ArgumentError,
-                "invalid value for :max_lifetime, expected a step-1 range, got: #{inspect(invalid)}"
+                "invalid value for :max_lifetime, expected a non-negative step-1 range, got: #{inspect(invalid)}"
 
         :error ->
           nil

--- a/lib/db_connection/holder.ex
+++ b/lib/db_connection/holder.ex
@@ -262,10 +262,10 @@ defmodule DBConnection.Holder do
   defp max_lifetime_reason(nil, _ts, _holder), do: nil
 
   defp max_lifetime_reason({start, interval_ms}, ts, holder) do
-    ellapsed = System.monotonic_time() - ts
+    elapsed = System.monotonic_time() - ts
 
     # First check if passed start then check if also the interval
-    if ellapsed > start and ellapsed > hash_holder(holder, interval_ms) + start do
+    if elapsed > start and elapsed > hash_holder(holder, interval_ms) + start do
       "max_lifetime exceeded"
     end
   end


### PR DESCRIPTION
- docstring: replace `idle_limit` (a count) with `2 * idle_interval` in the worst-case idle-wait formula; the addition was dimensionally incorrect.
- docstring: drop "and on checkout" — `conn(:ts)` is set only at connection establishment, never reset on checkout.
- docstring: fix "you ca set it" typo.
- connection_pool: reject negative or descending `:max_lifetime` ranges (e.g. `100..50//1`) at init instead of letting them flow into `:erlang.phash2/2` and be silently swallowed by the rescue in `Holder.maybe_disconnect/4`.
- holder: rename misspelled `ellapsed` to `elapsed`.