### PR TITLE
Use connection establishment time, not the last ping, for `max_lifetime` calculations

### DIFF
--- a/integration_test/connection_pool/max_lifetime_test.exs
+++ b/integration_test/connection_pool/max_lifetime_test.exs
@@ -1,3 +1,23 @@
+defmodule MaxLifetimeTest.Connection do
+  def connect(opts) do
+    {:ok, %{parent: Keyword.fetch!(opts, :parent), pings: 0}}
+  end
+
+  def disconnect(err, state) do
+    send(state.parent, {:max_lifetime_disconnect, err, state.pings})
+    :ok
+  end
+
+  def checkout(state), do: {:ok, state}
+  def checkin(state), do: {:ok, state}
+
+  def ping(state) do
+    state = %{state | pings: state.pings + 1}
+    send(state.parent, {:ping, state.pings})
+    {:ok, state}
+  end
+end
+
 defmodule MaxLifetimeTest do
   use ExUnit.Case, async: true
 
@@ -52,6 +72,31 @@ defmodule MaxLifetimeTest do
     {:ok, pool} = P.start_link(opts)
     assert_receive {:connected, conn}
     assert P.run(pool, fn _conn -> Process.sleep(500) end)
+    assert_receive {:disconnected, ^conn}
+    assert_receive {:connected, ^conn}
+  end
+
+  test "idle pings do not reset max_lifetime" do
+    opts = [
+      parent: self(),
+      pool: DBConnection.ConnectionPool,
+      pool_size: 1,
+      connection_listeners: [self()],
+      max_lifetime: 500..500,
+      idle_interval: 50,
+      backoff_min: 10
+    ]
+
+    {:ok, _pool} = DBConnection.start_link(MaxLifetimeTest.Connection, opts)
+
+    assert_receive {:connected, conn}
+    assert_receive {:ping, 1}, 500
+
+    assert_receive {:max_lifetime_disconnect,
+                    %DBConnection.ConnectionError{message: "max_lifetime exceeded"}, pings},
+                   2_000
+
+    assert pings > 0
     assert_receive {:disconnected, ^conn}
     assert_receive {:connected, ^conn}
   end

--- a/lib/db_connection/connection.ex
+++ b/lib/db_connection/connection.ex
@@ -61,6 +61,7 @@ defmodule DBConnection.Connection do
       pool: pool,
       tag: tag,
       timer: nil,
+      connected_at: nil,
       backoff: Backoff.new(opts),
       connection_listeners: Keyword.get(opts, :connection_listeners, []),
       after_connect: Keyword.get(opts, :after_connect),
@@ -85,14 +86,24 @@ defmodule DBConnection.Connection do
     else
       {:ok, state} when after_connect != nil ->
         ref = make_ref()
+        connected_at = System.monotonic_time()
         :gen_statem.cast(self(), {:after_connect, ref})
-        {:keep_state, %{s | state: state, client: {ref, :connect}}}
+        {:keep_state, %{s | state: state, client: {ref, :connect}, connected_at: connected_at}}
 
       {:ok, state} ->
         backoff = backoff && Backoff.reset(backoff)
         ref = make_ref()
+        connected_at = System.monotonic_time()
         :gen_statem.cast(self(), {:connected, ref})
-        {:keep_state, %{s | state: state, client: {ref, :connect}, backoff: backoff}}
+
+        {:keep_state,
+         %{
+           s
+           | state: state,
+             client: {ref, :connect},
+             backoff: backoff,
+             connected_at: connected_at
+         }}
 
       {:error, err} when is_nil(backoff) ->
         Logger.error(
@@ -154,7 +165,7 @@ defmodule DBConnection.Connection do
     demonitor(client)
     cancel_timer(timer)
     :ok = apply(mod, :disconnect, [err, state])
-    s = %{s | state: nil, client: :closed, timer: nil}
+    s = %{s | state: nil, client: :closed, timer: nil, connected_at: nil}
 
     notify_connection_listeners(:disconnected, s)
 
@@ -470,8 +481,8 @@ defmodule DBConnection.Connection do
     pool_update(state, %{s | client: nil, backoff: backoff})
   end
 
-  defp pool_update(state, %{pool: pool, tag: tag, mod: mod} = s) do
-    case Holder.update(pool, tag, mod, state) do
+  defp pool_update(state, %{pool: pool, tag: tag, mod: mod, connected_at: connected_at} = s) do
+    case Holder.update(pool, tag, mod, state, connected_at) do
       {:ok, ref} ->
         {:keep_state, %{s | client: {ref, :pool}, state: state}, :hibernate}
 

--- a/lib/db_connection/holder.ex
+++ b/lib/db_connection/holder.ex
@@ -8,7 +8,17 @@ defmodule DBConnection.Holder do
   @timeout 15000
   @time_unit 1000
 
-  Record.defrecord(:conn, [:connection, :module, :state, :lock, :ts, deadline: nil, status: :ok])
+  Record.defrecord(:conn, [
+    :connection,
+    :module,
+    :state,
+    :lock,
+    :ts,
+    :connected_at,
+    deadline: nil,
+    status: :ok
+  ])
+
   Record.defrecord(:pool_ref, [:pool, :reference, :deadline, :holder, :lock])
 
   @type t :: :ets.tid()
@@ -17,11 +27,20 @@ defmodule DBConnection.Holder do
   ## Holder API
 
   @spec new(pid, reference, module, term) :: t
-  def new(pool, ref, mod, state) do
+  @spec new(pid, reference, module, term, integer) :: t
+  def new(pool, ref, mod, state, connected_at \\ System.monotonic_time()) do
     # Insert before setting heir so that pool can't receive empty table
     holder = :ets.new(__MODULE__, [:public, :ordered_set, decentralized_counters: true])
 
-    conn = conn(connection: self(), module: mod, state: state, ts: System.monotonic_time())
+    conn =
+      conn(
+        connection: self(),
+        module: mod,
+        state: state,
+        ts: System.monotonic_time(),
+        connected_at: connected_at
+      )
+
     true = :ets.insert_new(holder, conn)
 
     :ets.setopts(holder, {:heir, pool, ref})
@@ -29,8 +48,9 @@ defmodule DBConnection.Holder do
   end
 
   @spec update(pid, reference, module, term) :: {:ok, t} | :error
-  def update(pool, ref, mod, state) do
-    holder = new(pool, ref, mod, state)
+  @spec update(pid, reference, module, term, integer) :: {:ok, t} | :error
+  def update(pool, ref, mod, state, connected_at \\ System.monotonic_time()) do
+    holder = new(pool, ref, mod, state, connected_at)
 
     try do
       :ets.give_away(holder, pool, {:checkin, ref, System.monotonic_time()})
@@ -244,10 +264,10 @@ defmodule DBConnection.Holder do
   @spec maybe_disconnect(t, integer, non_neg_integer, {integer, non_neg_integer} | nil) ::
           boolean()
   def maybe_disconnect(holder, start, interval_ms, lifetime) do
-    ts = :ets.lookup_element(holder, :conn, conn(:ts) + 1)
+    [conn(ts: holder_ts, connected_at: connected_at)] = :ets.lookup(holder, :conn)
 
-    disconnect_all_reason(start, interval_ms, ts, holder) ||
-      max_lifetime_reason(lifetime, ts, holder)
+    disconnect_all_reason(start, interval_ms, holder_ts, holder) ||
+      max_lifetime_reason(lifetime, connected_at, holder)
   rescue
     _ -> false
   else
@@ -260,6 +280,7 @@ defmodule DBConnection.Holder do
   end
 
   defp max_lifetime_reason(nil, _ts, _holder), do: nil
+  defp max_lifetime_reason(_lifetime, nil, _holder), do: nil
 
   defp max_lifetime_reason({start, interval_ms}, ts, holder) do
     elapsed = System.monotonic_time() - ts


### PR DESCRIPTION
The holder's ts is reset on every update, which happens on pings too. This renders `max_lifetime` often useless since along with the default `idle_interval` the timestamp is reset every second.

This PR makes `max_lifetime` logic use connection establishment time, which is passed along on holder updates. The new test fails without changes made in this PR.