### PR TITLE
fix: include pool label in timeout errors

### DIFF
--- a/integration_test/cases/queue_test.exs
+++ b/integration_test/cases/queue_test.exs
@@ -42,6 +42,29 @@ defmodule QueueTest do
     end
   end
 
+  test "queue drop timeout includes pool label when present" do
+    if function_exported?(:proc_lib, :get_label, 1) do
+      stack = [{:ok, :state}, {:idle, :state}, {:idle, :state}]
+      {:ok, agent} = A.start_link(stack)
+
+      opts = [
+        agent: agent,
+        parent: self(),
+        label: TestRepo,
+        queue_target: 10,
+        queue_interval: 10
+      ]
+
+      {:ok, pool} = P.start_link(opts)
+
+      P.run(pool, fn _ ->
+        assert_raise DBConnection.ConnectionError,
+                     ~r/connection not available from TestRepo and request was dropped from queue after \d+ms/,
+                     fn -> P.run(pool, fn _ -> flunk("got connection") end, timeout: 10) end
+      end)
+    end
+  end
+
   test "queue many async timeouts" do
     stack = [{:ok, :state}] ++ List.duplicate({:idle, :state}, 20)
     {:ok, agent} = A.start_link(stack)

--- a/lib/db_connection.ex
+++ b/lib/db_connection.ex
@@ -431,6 +431,10 @@ defmodule DBConnection do
     * `:idle_limit` - The number of connections to ping on each `:idle_interval`.
       Defaults to the pool size (all connections).
 
+    * `:label` - A label to include in relevant connection pool error messages.
+      Libraries built on top of DBConnection, such as Ecto, can use this to
+      identify the pool that timed out.
+
     * `:max_restarts` and `:max_seconds` - Configures the `:max_restarts` and
       `:max_seconds` for the connection pool supervisor (see the `Supervisor` docs).
       Typically speaking the connection process doesn't terminate, except due to
@@ -649,6 +653,7 @@ defmodule DBConnection do
       :configure,
       :idle_interval,
       :idle_limit,
+      :label,
       :max_restarts,
       :max_seconds,
       :name,

--- a/lib/db_connection/connection.ex
+++ b/lib/db_connection/connection.ex
@@ -312,7 +312,7 @@ defmodule DBConnection.Connection do
       when is_reference(timer) do
     message =
       "client #{Util.inspect_pid(pid)} timed out because it checked out " <>
-        "#{Util.pool_label_info(s.pool)}the connection for longer than #{timeout}ms"
+        "the connection#{Util.pool_label_info(s.pool)} for longer than #{timeout}ms"
 
     exc =
       case Process.info(pid, :current_stacktrace) do

--- a/lib/db_connection/connection.ex
+++ b/lib/db_connection/connection.ex
@@ -312,7 +312,7 @@ defmodule DBConnection.Connection do
       when is_reference(timer) do
     message =
       "client #{Util.inspect_pid(pid)} timed out because it checked out " <>
-        "the connection for longer than #{timeout}ms"
+        "#{Util.pool_label_info(s.pool)}the connection for longer than #{timeout}ms"
 
     exc =
       case Process.info(pid, :current_stacktrace) do

--- a/lib/db_connection/connection_pool.ex
+++ b/lib/db_connection/connection_pool.ex
@@ -48,6 +48,10 @@ defmodule DBConnection.ConnectionPool do
   def init({mod, opts}) do
     DBConnection.register_as_pool(mod)
 
+    if label = opts[:label] do
+      Util.set_label({__MODULE__, label})
+    end
+
     queue = :ets.new(__MODULE__.Queue, [:protected, :ordered_set, decentralized_counters: true])
 
     max_lifetime =
@@ -187,7 +191,7 @@ defmodule DBConnection.ConnectionPool do
     if Holder.handle_deadline(holder, deadline) do
       message =
         "client #{Util.inspect_pid(pid)} timed out because " <>
-          "it queued and checked out the connection for longer than #{len}ms"
+          "#{Util.pool_label_info(self())}it queued and checked out the connection for longer than #{len}ms"
 
       exc =
         case Process.info(pid, :current_stacktrace) do

--- a/lib/db_connection/connection_pool.ex
+++ b/lib/db_connection/connection_pool.ex
@@ -191,7 +191,7 @@ defmodule DBConnection.ConnectionPool do
     if Holder.handle_deadline(holder, deadline) do
       message =
         "client #{Util.inspect_pid(pid)} timed out because " <>
-          "#{Util.pool_label_info(self())}it queued and checked out the connection for longer than #{len}ms"
+          "it queued and checked out the connection#{Util.pool_label_info(self())} for longer than #{len}ms"
 
       exc =
         case Process.info(pid, :current_stacktrace) do
@@ -271,7 +271,7 @@ defmodule DBConnection.ConnectionPool do
     select_slow = [{match, guards, [{{:"$1", :"$2"}}]}]
 
     for {sent, from} <- :ets.select(queue, select_slow) do
-      drop(time - sent, from)
+      drop(time - sent, from, Util.pool_label_info(self()))
     end
 
     :ets.select_delete(queue, [{match, guards, [true]}])
@@ -340,7 +340,7 @@ defmodule DBConnection.ConnectionPool do
     case :ets.first(queue) do
       {sent, _, from} = key when time - sent > timeout ->
         :ets.delete(queue, key)
-        drop(time - sent, from)
+        drop(time - sent, from, Util.pool_label_info(self()))
         dequeue_slow(time, timeout, holder, queue, codel, ts)
 
       {sent, _, from} = key ->
@@ -365,9 +365,9 @@ defmodule DBConnection.ConnectionPool do
     end
   end
 
-  defp drop(delay, from) do
+  defp drop(delay, from, pool_label_info) do
     message = """
-    [#{ancestor()}] connection not available and request was dropped from queue after #{delay}ms. \
+    [#{ancestor()}] connection not available#{pool_label_info} and request was dropped from queue after #{delay}ms. \
     This means requests are coming in and your connection pool cannot serve them fast enough. \
     You can address this by:
 

--- a/lib/db_connection/ownership/proxy.ex
+++ b/lib/db_connection/ownership/proxy.ex
@@ -70,7 +70,7 @@ defmodule DBConnection.Ownership.Proxy do
     if Holder.handle_deadline(holder, deadline) do
       message =
         "client #{Util.inspect_pid(pid)} timed out because " <>
-          "#{Util.pool_label_info(self())}it queued and checked out the connection for longer than #{len}ms"
+          "it queued and checked out the connection#{Util.pool_label_info(self())} for longer than #{len}ms"
 
       shutdown(message, state)
     else
@@ -84,7 +84,7 @@ defmodule DBConnection.Ownership.Proxy do
       ) do
     message =
       "owner #{Util.inspect_pid(pid)} timed out because " <>
-        "#{Util.pool_label_info(self())}it owned the connection for longer than #{timeout}ms (set via the :ownership_timeout option)"
+        "it owned the connection#{Util.pool_label_info(self())} for longer than #{timeout}ms (set via the :ownership_timeout option)"
 
     # We don't invoke shutdown because this is always a disconnect, even if there is no client.
     # On the other hand, those timeouts are unlikely to trigger, as it defaults to 2 mins.

--- a/lib/db_connection/ownership/proxy.ex
+++ b/lib/db_connection/ownership/proxy.ex
@@ -22,6 +22,10 @@ defmodule DBConnection.Ownership.Proxy do
 
   @impl true
   def init({caller, pool, pool_opts}) do
+    if label = pool_opts[:label] do
+      Util.set_label({__MODULE__, label})
+    end
+
     pool_opts =
       pool_opts
       |> Keyword.put(:timeout, :infinity)
@@ -66,7 +70,7 @@ defmodule DBConnection.Ownership.Proxy do
     if Holder.handle_deadline(holder, deadline) do
       message =
         "client #{Util.inspect_pid(pid)} timed out because " <>
-          "it queued and checked out the connection for longer than #{len}ms"
+          "#{Util.pool_label_info(self())}it queued and checked out the connection for longer than #{len}ms"
 
       shutdown(message, state)
     else
@@ -80,7 +84,7 @@ defmodule DBConnection.Ownership.Proxy do
       ) do
     message =
       "owner #{Util.inspect_pid(pid)} timed out because " <>
-        "it owned the connection for longer than #{timeout}ms (set via the :ownership_timeout option)"
+        "#{Util.pool_label_info(self())}it owned the connection for longer than #{timeout}ms (set via the :ownership_timeout option)"
 
     # We don't invoke shutdown because this is always a disconnect, even if there is no client.
     # On the other hand, those timeouts are unlikely to trigger, as it defaults to 2 mins.

--- a/lib/db_connection/util.ex
+++ b/lib/db_connection/util.ex
@@ -53,6 +53,13 @@ defmodule DBConnection.Util do
 
   def pool_label(_other), do: nil
 
+  def pool_label_info(pid) do
+    case pool_label(pid) do
+      nil -> ""
+      label -> "(#{inspect(label)}) "
+    end
+  end
+
   # Get a process label if `:proc_lib.get_label/1` is available.
   defp get_label(pid) do
     if function_exported?(:proc_lib, :get_label, 1) do

--- a/lib/db_connection/util.ex
+++ b/lib/db_connection/util.ex
@@ -56,7 +56,7 @@ defmodule DBConnection.Util do
   def pool_label_info(pid) do
     case pool_label(pid) do
       nil -> ""
-      label -> "(#{inspect(label)}) "
+      label -> " from #{inspect(label)}"
     end
   end
 

--- a/test/db_connection_test.exs
+++ b/test/db_connection_test.exs
@@ -63,6 +63,17 @@ defmodule DBConnectionTest do
     end
   end
 
+  describe "pool label formatting" do
+    test "formats pool labels for timeout errors on supported runtimes" do
+      if function_exported?(Process, :set_label, 1) do
+        DBConnection.Util.set_label({DBConnection.ConnectionPool, MyApp.Repo})
+        assert DBConnection.Util.pool_label_info(self()) == "(MyApp.Repo) "
+      else
+        assert DBConnection.Util.pool_label_info(self()) == ""
+      end
+    end
+  end
+
   describe "connection_module/1" do
     setup do
       {:ok, agent} = A.start_link([{:ok, :state}, {:idle, :state}, {:idle, :state}])

--- a/test/db_connection_test.exs
+++ b/test/db_connection_test.exs
@@ -45,6 +45,7 @@ defmodule DBConnectionTest do
                :configure,
                :idle_interval,
                :idle_limit,
+               :label,
                :max_restarts,
                :max_seconds,
                :name,
@@ -60,17 +61,6 @@ defmodule DBConnectionTest do
   describe "available_connection_options/0" do
     test "returns all available function options" do
       assert DBConnection.available_connection_options() == [:log, :queue, :timeout, :deadline]
-    end
-  end
-
-  describe "pool label formatting" do
-    test "formats pool labels for timeout errors on supported runtimes" do
-      if function_exported?(Process, :set_label, 1) do
-        DBConnection.Util.set_label({DBConnection.ConnectionPool, MyApp.Repo})
-        assert DBConnection.Util.pool_label_info(self()) == "(MyApp.Repo) "
-      else
-        assert DBConnection.Util.pool_label_info(self()) == ""
-      end
     end
   end
 


### PR DESCRIPTION
## Summary

DBConnection already receives a pool `:label` from callers such as Ecto SQL (`connection.child_spec([label: name] ++ config)`). This PR uses that existing label in timeout diagnostics so applications with multiple Repo pools can identify which pool exhausted its queue or held a checkout too long.

Without the label, timeout errors only say that a client queued, checked out, or owned "the connection" for too long. In an Ecto application with several repos or partitioned pools, that is not enough information to know which Repo needs attention.

## Changes

- labels default connection pool and ownership proxy processes when `:label` is provided
- includes the label in checkout, queue-drop, and ownership timeout messages as `connection from MyApp.Repo`
- documents `:label` as a DBConnection start option and includes it in `available_start_options/0`
- adds behavior-level coverage for the queue-drop timeout message instead of only testing the formatting helper

## Ecto behavior

Ecto SQL already passes the repo name as the DBConnection label when building the connection child spec. With this change, a timeout from an Ecto repo pool can point back to the configured repo name in the DBConnection error message.

## Verification

- `mix format --check-formatted`
- `mix test test/db_connection_test.exs integration_test/cases/queue_test.exs`
